### PR TITLE
docs: remove some unicode icons from diagram

### DIFF
--- a/docs/arch.gv
+++ b/docs/arch.gv
@@ -42,7 +42,7 @@ digraph {
     S3 -> publish_tools [dir="back"]
     db -> publish_tools [dir="back"]
 
-    client [label="💻 client"]
+    client [label="client"]
     publish_tools [label="publishing tools", style="rounded", rank="max", shape="box"]
 
     db [
@@ -125,7 +125,7 @@ digraph {
     ];
 
     subgraph cluster_0 {
-        label=< <b>🖧 CloudFront CDN</b> >
+        label=< <b>CloudFront CDN</b> >
         style="rounded";
         controller;
         subgraph cluster_1 {


### PR DESCRIPTION
Unfortunately, the chosen characters here don't render correctly
when graphviz runs on Travis CI machines.  There is probably a way
to fix that by installing more fonts, but it may not be worth
spending the time on that.

Rendering as an SVG instead would also fix this but seems to
introduce its own problems.