### PR TITLE
Support want-digest request headers [DELIVERY-8988]

### DIFF
--- a/exodus_lambda/functions/origin_response.py
+++ b/exodus_lambda/functions/origin_response.py
@@ -1,5 +1,6 @@
 import logging
 import re
+from base64 import b64encode
 
 from .base import LambdaBase
 
@@ -12,6 +13,13 @@ class OriginResponse(LambdaBase):
 
         request = event["Records"][0]["cf"]["request"]
         response = event["Records"][0]["cf"]["response"]
+
+        if "headers" in request and "want-digest" in request["headers"]:
+            sum_hex = request["uri"].replace("/", "", 1)
+            sum_b64 = b64encode(bytes.fromhex(sum_hex)).decode()
+            response["headers"]["digest"] = [
+                {"key": "Digest", "value": f"id-sha-256={sum_b64}"}
+            ]
 
         max_age = self.conf["headers"]["max_age"]
         max_age_pattern_whitelist = [

--- a/tests/functions/test_origin_response.py
+++ b/tests/functions/test_origin_response.py
@@ -13,30 +13,29 @@ max_age = conf["headers"]["max_age"]
 
 
 @pytest.mark.parametrize(
-    "test_input",
+    "original_uri, want_digest",
     [
-        "/some/repo/listing",
-        "/some/repo/repodata/repomd.xml",
-        "/some/repo/ostree/repo/refs/heads/ok/test",
+        ("/some/repo/listing", True),
+        ("/some/repo/repodata/repomd.xml", True),
+        ("/some/repo/ostree/repo/refs/heads/ok/test", False),
     ],
 )
-def test_origin_response_valid_headers(
-    test_input,
-    expected=[{"key": "Cache-Control", "value": "max-age={}".format(max_age)}],
-):
+def test_origin_response_valid_headers(original_uri, want_digest):
     event = {
         "Records": [
             {
                 "cf": {
                     "request": {
+                        "uri": "/be7f3007df3e51fb48fff57da9c01c52e6b8e60eceacab"
+                        "7aaf0e05b57578493a",
                         "headers": {
                             "exodus-original-uri": [
                                 {
                                     "key": "exodus-original-uri",
-                                    "value": test_input,
+                                    "value": original_uri,
                                 }
                             ]
-                        }
+                        },
                     },
                     "response": {"headers": {}},
                 }
@@ -44,15 +43,33 @@ def test_origin_response_valid_headers(
         ]
     }
 
+    expected_headers = {
+        "cache-control": [
+            {"key": "Cache-Control", "value": f"max-age={max_age}"}
+        ]
+    }
+
+    if want_digest:
+        event["Records"][0]["cf"]["request"]["headers"]["want-digest"] = [
+            {"key": "Want-Digest", "value": "sha-256"}
+        ]
+        expected_headers["digest"] = [
+            {
+                "key": "Digest",
+                "value": "id-sha-256=vn8wB98+UftI//V9qcAcUua45g7OrKt6rw"
+                "4FtXV4STo=",
+            }
+        ]
+
     response = OriginResponse(conf_file=CONF_PATH).handler(event, context=None)
-    assert response["headers"]["cache-control"] == expected
+    assert response["headers"] == expected_headers
 
 
 @pytest.mark.parametrize(
     "test_input",
     ["/some/repo/some-rpm.rpm", "/some/repo/ostree/repo/refs/heads/nope"],
 )
-def test_origin_response_empty_headers(test_input, expected={}):
+def test_origin_response_empty_headers(test_input):
     event = {
         "Records": [
             {"cf": {"request": {"headers": {}}, "response": {"headers": {}}}}
@@ -60,7 +77,7 @@ def test_origin_response_empty_headers(test_input, expected={}):
     }
 
     response = OriginResponse(conf_file=CONF_PATH).handler(event, context=None)
-    assert response["headers"] == expected
+    assert response["headers"] == {}
 
 
 def test_origin_response_missing_headers():


### PR DESCRIPTION
This commit enables id-sha-256 digest header in the response for any
want-digest, regardless of requested algorithm.