### PR TITLE
Ensure "tox -e package" creates clean packages

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ whitelist_externals=
     cp
 commands_pre=
 commands=
-    rm -rf ./package
+    rm -rf ./package package.zip
 
     # --require-hashes and then --no-deps to avoid using anything untrusted from PyPI
     pip install --require-hashes -r requirements.txt --target ./package


### PR DESCRIPTION
The zip command, by default, updates rather than overwrites any
existing output file. This would result in "tox -e package"
updating package.zip rather than replacing it, which means old
files could remain (e.g. old versions of dependencies, or files
which have since been renamed).

Avoid this by creating a new package.zip every time.