### PR TITLE
Add buildspec.yml for AWS CodeBuild [RHELDST-20, RHELDST-24]

### DIFF
--- a/configuration/buildspec.yaml
+++ b/configuration/buildspec.yaml
@@ -1,0 +1,11 @@
+version: 0.2
+
+phases:
+  build:
+    commands:
+      - ./scripts/build-package
+
+artifacts:
+  files:
+    - ./package/exodus-lambda-pkg.yaml
+  discard-paths: yes

--- a/configuration/lambda_config.json
+++ b/configuration/lambda_config.json
@@ -1,7 +1,7 @@
 {
   "table": {
-    "name": "exodus",
-    "region": "us-east-1"
+    "name": "exodus-cdn-$ENV_TYPE",
+    "region": "$AWS_REGION"
   },
   "headers": {
     "max_age": "600"

--- a/scripts/build-package
+++ b/scripts/build-package
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+pip install --require-hashes -r requirements.txt --target ./package
+pip install --no-deps --target ./package .
+cp ./configuration/exodus-lambda-deploy.yaml ./package
+envsubst < ./configuration/lambda_config.json > ./package/lambda_config.json
+aws cloudformation package \
+	--template ./package/exodus-lambda-deploy.yaml \
+	--s3-bucket exodus-pipeline-artifacts \
+	--output-template-file ./package/exodus-lambda-pkg.yaml


### PR DESCRIPTION
This commit introduces a buildspec.yml file to provide to AWS CodeBuild during
the build phase of the exodus CodePipeline. CodeBuild packages the exodus Lambda@Edge
code from the latest verified git tag into a deployable CloudFormation template.

Additionally, the Lambda@Edge function configuration is dynamically generated during the Build phase.