### PR TITLE
Add deployment documentation

### DIFF
--- a/docs/arch.rst
+++ b/docs/arch.rst
@@ -1,3 +1,5 @@
+.. _arch_ref:
+
 Architecture
 ============
 
@@ -10,11 +12,13 @@ in the delivery of content via the CDN.
 
 .. graphviz:: arch.gv
 
-- Numbered connections represent the sequence of events when the CDN processes a request.
-- For clarity, SHA256 checksums have been truncated (as in ``8e7750e50734f...``). In reality,
-  the system stores complete checksums.
-- The CloudFront CDN shown in the above diagram may itself be hosted behind another CDN,
-  so client requests may pass through additional layers not expressed here.
+- Numbered connections represent the sequence of events when the CDN processes
+  a request.
+- For clarity, SHA256 checksums have been truncated (as in
+  ``8e7750e50734f...``). In reality, the system stores complete checksums.
+- The CloudFront CDN shown in the above diagram may itself be hosted behind
+  another CDN, so client requests may pass through additional layers not
+  expressed here.
 
 
 Components
@@ -54,58 +58,65 @@ S3
     A single bucket is used, configured as the origin of the CloudFront CDN.
 
     One object corresponds to one file which can be downloaded from the CDN;
-    this includes files considered to be content (such as RPMs) and files considered
-    to be metadata (such as yum repo metadata files).
+    this includes files considered to be content (such as RPMs) and files
+    considered to be metadata (such as yum repo metadata files).
 
-    Each object's key is its own SHA256 checksum, ensuring that content accessible
-    via many paths on the CDN need only be stored once.
+    Each object's key is its own SHA256 checksum, ensuring that content
+    accessible via many paths on the CDN need only be stored once.
 
-    S3 metadata is used in some cases to customize the response behavior of each object;
-    for example, metadata is used to adjust ``Content-Type`` headers in responses.
-    Publishing tools are responsible for setting this metadata accurately.
+    S3 metadata is used in some cases to customize the response behavior of
+    each object; for example, metadata is used to adjust ``Content-Type``
+    headers in responses. Publishing tools are responsible for setting this
+    metadata accurately.
 
     For more information about the data contained here, see :ref:`schema_ref`.
 
 exodus-lambda
-    A project including Python-based implementations of `Lambda@Edge`_ functions for the CDN.
+    A project including Python-based implementations of `Lambda@Edge`_
+    functions for the CDN.
 
     You are currently reading the documentation of this project.
 
 origin_request
-    A `Lambda@Edge`_ function connected to "origin request" events in CloudFront.
+    A `Lambda@Edge`_ function connected to "origin request" events in
+    CloudFront.
 
-    This function is primarily responsible for translating the path given in the client's
-    request into an S3 object key via a DynamoDB query.  Assuming the client has requested
-    existing content, this Lambda function will rewrite the request's URI into a valid S3
-    object key before returning the request to the controller.  The function itself does
-    not request data from S3, nor generate a response directly.
+    This function is primarily responsible for translating the path given in
+    the client's request into an S3 object key via a DynamoDB query.  Assuming
+    the client has requested existing content, this Lambda function will
+    rewrite the request's URI into a valid S3 object key before returning the
+    request to the controller. The function itself does not request data from
+    S3, nor generate a response directly.
 
-    For more information about this function's behavior, see :ref:`function_ref`.
+    For more information about this function's behavior, see
+    :ref:`function_ref`.
 
 origin_response
-    A `Lambda@Edge`_ function connected to "origin response" events in CloudFront.
+    A `Lambda@Edge`_ function connected to "origin response" events in
+    CloudFront.
 
-    This function is primarily responsible for tweaking certain response headers
-    before allowing CloudFront to serve the response to clients.  For example,
-    caching behavior is influenced by setting a Cache-Control header for certain
-    responses.
+    This function is primarily responsible for tweaking certain response
+    headers before allowing CloudFront to serve the response to clients. For
+    example, caching behavior is influenced by setting a Cache-Control header
+    for certain responses.
 
-    For more information about this function's behavior, see :ref:`function_ref`.
+    For more information about this function's behavior, see
+    :ref:`function_ref`.
 
 publishing tools
     Represents the tools used by Red Hat to publish content onto the CDN.
 
-    These tools insert data into the CDN's S3 and DynamoDB services in order to publish
-    content.
+    These tools insert data into the CDN's S3 and DynamoDB services in order to
+    publish content.
 
-    A further explanation of these tools is out of scope for this document; it suffices
-    to know that the tools are designed with an awareness of the CDN architecture
-    described here.
-
-.. _Lambda@Edge: https://aws.amazon.com/lambda/edge/
+    A further explanation of these tools is out of scope for this document; it
+    suffices to know that the tools are designed with an awareness of the CDN
+    architecture described here.
 
 .. _Amazon CloudFront: https://aws.amazon.com/cloudfront/
 
 .. _Amazon DynamoDB: https://aws.amazon.com/dynamodb/
 
 .. _Amazon S3: https://aws.amazon.com/s3/
+
+.. _Lambda@Edge: https://aws.amazon.com/lambda/edge/

--- a/docs/deploy.rst
+++ b/docs/deploy.rst
@@ -1,0 +1,113 @@
+Deployment
+==========
+
+
+CDN Storage (Bucket & Table)
+----------------------------
+
+Each environment (dev, stage, prod, etc.) requires an `Amazon S3`_ bucket and a
+`Amazon DynamoDB`_ table, as illustrated in :ref:`arch_ref`.
+
+An `AWS CloudFormation`_ template is available to create these bucket-table
+pairs, exodus-storage.yaml, run by the `AWS CLI`_ command
+``aws cloudformation deploy``.
+
+- Parameters
+    - env
+        The environment in which to deploy functions.
+        Available values: dev (default), stage, prod
+
+Additionally, an `Origin Access Identity`_ is created for use with
+`Amazon CloudFront`_ distributions.
+
+**Note**: The AWS region in which these resources are created is defined by
+local configuration or environment variables. See: `AWS Config`_.
+
+| **Example**:
+| $ export AWS_DEFAULT_REGION=us-east-1
+| $ aws cloudformation deploy ``\``
+|   --template-file configuration/exodus-storage.yaml ``\``
+|   --stack-name ... ``\``
+|   --capabilities ... ``\``
+|   --parameter-overrides env=...
+
+Lambda Deployment Pipelines
+---------------------------
+
+In order for the CDN to work as designed, `Lambda@Edge`_ functions must be
+deployed to handle requests to and responses from the CDN. To automate the
+deployment of these functions, we use `AWS CodePipeline`_ pipelines. The
+pipelines retrieve the source code, build the deployment package, and publish
+it to `Lambda@Edge`_.
+
+An `AWS CloudFormation`_ template is available to create these pipelines,
+exodus-pipeline.yaml, run by the `AWS CLI`_ command
+``aws cloudformation deploy``.
+
+- Parameters
+    - env
+        The environment in which to deploy functions.
+        Available values: dev (default), stage, prod
+    - oai
+        The origin access identity ID associated with the environment,
+        created alongside the environment's bucket-table pair.
+    - githubToken
+        A GitHub access token for repository authentication
+    - region
+        The region in which resources are established.
+        Should align with the environment's bucket-table pair.
+    - email
+        The email address to which notifications are sent.
+
+| **Example**:
+| $ export AWS_DEFAULT_REGION=us-east-1
+| $ aws cloudformation deploy ``\``
+|   --template-file configuration/exodus-pipeline.yaml ``\``
+|   --stack-name ... ``\``
+|   --capabilities ... ``\``
+|   --parameter-overrides ``\``
+|       env=... oai=... githubToken=... region=... email=...
+
+Lambda Functions
+----------------
+
+The `Lambda@Edge`_ functions defined in this repository are intended to be
+deployed by `AWS CodePipeline`_ pipelines, triggered by pushes to designated
+git branch(es). However, the `AWS CloudFormation`_ template for function
+deployment, exodus-lambda-deploy.yaml, can be run by the `AWS CLI`_ command
+``aws cloudformation deploy`` once packaged.
+
+- Parameters
+    - env
+        The environment in which to deploy functions.
+        Available values: dev (default), stage, prod
+    - oai
+        The origin access identity ID associated with the environment,
+        created alongside the environment's bucket-table pair.
+
+| **Example**:
+| $ export AWS_DEFAULT_REGION=us-east-1
+| $ ./scripts/build-package
+| $ aws cloudformation deploy ``\``
+|   --template-file configuration/exodus-lambda-pkg.yaml ``\``
+|   --stack-name ... ``\``
+|   --capabilities ... ``\``
+|   --parameter-overrides env=... oai=...
+
+.. _Amazon S3: https://aws.amazon.com/s3/
+
+.. _Amazon DynamoDB: https://aws.amazon.com/dynamodb/
+
+.. _AWS CloudFormation: https://aws.amazon.com/cloudformation/
+
+.. _AWS CLI: https://aws.amazon.com/cli/
+
+.. _Origin Access Identity: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-restricting-access-to-s3.html
+
+.. _Amazon CloudFront: https://aws.amazon.com/cloudfront/
+
+.. _AWS Config: https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html
+
+.. _Lambda@Edge: https://aws.amazon.com/lambda/edge/
+
+.. _AWS CodePipeline: https://aws.amazon.com/codepipeline/

--- a/docs/functions/origin_request.rst
+++ b/docs/functions/origin_request.rst
@@ -1,8 +1,8 @@
 origin_request
 =========
 
-The origin_request function provides mapping from a web URI, delivered by an AWS
-CloudFront event, to the key of an object in an AWS S3 bucket.
+The origin_request function provides mapping from a web URI, delivered by an
+AWS CloudFront event, to the key of an object in an AWS S3 bucket.
 
 Using this function, a URI like "/path/to/s3/file" would be transformed to
 something like "/some-s3-file-object-key".
@@ -26,8 +26,8 @@ an S3 bucket.
 
 Configuration
 ^^^^^^^^^^^^^
-The origin_request function must be deployed with the lambda_config.json configuration
-file.
+The origin_request function must be deployed with the lambda_config.json
+configuration file.
 
 - table
     The DynamoDB table from which to derive path to key mapping.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,5 +8,6 @@ AWS Lambda functions for Red Hat's Content Delivery Network
    :caption: Contents:
 
    arch
+   deploy
    function-reference
    schema-reference


### PR DESCRIPTION
This commit introduces a documentation page dedicated to deployment
methods for AWS resources using AWS CloudFormation templates.