### PR TITLE
Enable configuration of exodus-lambda loggers [RHELDST-662]

### DIFF
--- a/configuration/lambda_config.json
+++ b/configuration/lambda_config.json
@@ -12,5 +12,27 @@
   },
   "headers": {
     "max_age": "600"
+  },
+  "logging": {
+    "version": 1,
+    "incremental": "True",
+    "disable_existing_loggers": "False",
+    "formatters": {
+      "default": {
+        "format": "%(asctime)s - %(levelname)s - %(aws_request_id)s - %(message)s\n",
+        "datefmt": "%Y-%m-%d %H:%M:%S"
+      }
+    },
+    "loggers": {
+      "origin-response": {
+        "level": "WARNING"
+      },
+      "origin-request": {
+        "level": "WARNING"
+      },
+      "default": {
+        "level": "WARNING"
+      }
+    }
   }
 }

--- a/exodus_lambda/functions/origin_response.py
+++ b/exodus_lambda/functions/origin_response.py
@@ -1,13 +1,13 @@
-import logging
 import re
 from base64 import b64encode
 
 from .base import LambdaBase
 
-LOG = logging.getLogger("origin-response")
-
 
 class OriginResponse(LambdaBase):
+    def __init__(self, conf_file="lambda_config.json"):
+        super().__init__("origin-response", conf_file)
+
     def handler(self, event, context):
         # pylint: disable=unused-argument
 
@@ -35,7 +35,7 @@ class OriginResponse(LambdaBase):
             ]
 
         except KeyError:
-            LOG.debug(
+            self.logger.debug(
                 "Could not read exodus-original-uri from response",
                 exc_info=True,
             )
@@ -45,12 +45,9 @@ class OriginResponse(LambdaBase):
             for pattern in max_age_pattern_whitelist:
                 if re.match(pattern, original_uri):
                     response["headers"]["cache-control"] = [
-                        {
-                            "key": "Cache-Control",
-                            "value": f"max-age={max_age}",
-                        }
+                        {"key": "Cache-Control", "value": f"max-age={max_age}"}
                     ]
-                    LOG.info(
+                    self.logger.info(
                         "Cache-Control header added for '%s'", original_uri
                     )
 

--- a/tests/functions/test_base.py
+++ b/tests/functions/test_base.py
@@ -1,8 +1,12 @@
 import pytest
 
+import logging
+
 from exodus_lambda.functions.base import LambdaBase
+from test_utils.utils import generate_test_config
 
 CONF_PATH = "configuration/lambda_config.json"
+TEST_CONF = generate_test_config(CONF_PATH)
 
 
 def test_base_handler():
@@ -30,3 +34,27 @@ def test_base_region(env_var, exp_var, monkeypatch):
     # Environment variable is unset
     monkeypatch.delenv("AWS_REGION")
     assert base.region == "us-east-1"
+
+
+def test_logger_config(caplog):
+    base_obj = LambdaBase(conf_file=TEST_CONF)
+
+    with caplog.at_level(logging.DEBUG):
+        base_obj.logger.debug("debug message")
+        base_obj.logger.info("info message")
+        base_obj.logger.warning("warning message")
+    assert "[DEBUG] - debug message\n" in caplog.text
+    assert "[INFO] - info message\n" in caplog.text
+    assert "[WARNING] - warning message\n" in caplog.text
+
+
+def test_root_logger_without_handlers(caplog):
+    """
+    A root logger without handlers should not cause the program to crash.
+    """
+    root_logger = logging.getLogger()
+    root_logger.handlers = []
+    base_obj = LambdaBase(conf_file=TEST_CONF)
+    base_obj.logger.warning("warning message")
+    assert root_logger.handlers == []
+    assert "warning message" not in caplog.text

--- a/tests/test_utils/utils.py
+++ b/tests/test_utils/utils.py
@@ -1,0 +1,13 @@
+import json
+
+
+def generate_test_config(conf="configuration/lambda_config.json"):
+    with open(conf, "r") as json_file:
+        conf = json.load(json_file)
+    conf["logging"]["formatters"]["default"][
+        "format"
+    ] = "[%(levelname)s] - %(message)s\n"
+    conf["logging"]["loggers"]["origin-response"]["level"] = "DEBUG"
+    conf["logging"]["loggers"]["origin-request"]["level"] = "DEBUG"
+    conf["logging"]["loggers"]["default"]["level"] = "DEBUG"
+    return conf


### PR DESCRIPTION
The loggers are configured according to a config file in the deployment
package. The levels, formatting, and handlers of the loggers may be
configured in accordance with the logging.config.dictConfig documentation.

By default, the current behavior of the loggers is maintained; the
loggers are configured to log messages at the warning level and higher.