### PR TITLE
Enable multiple table regions in config, origin_request [RHELDST-663]

### DIFF
--- a/configuration/lambda_config.json
+++ b/configuration/lambda_config.json
@@ -1,7 +1,14 @@
 {
   "table": {
     "name": "exodus-cdn-$ENV_TYPE",
-    "region": "$AWS_REGION"
+    "available_regions": [
+      "us-east-1",
+      "us-west-1",
+      "ap-east-1",
+      "ap-south-1",
+      "ap-southeast-2",
+      "eu-central-1"
+    ]
   },
   "headers": {
     "max_age": "600"

--- a/exodus_lambda/functions/base.py
+++ b/exodus_lambda/functions/base.py
@@ -1,4 +1,5 @@
 import json
+import os
 
 
 class LambdaBase(object):
@@ -13,6 +14,15 @@ class LambdaBase(object):
                 self._conf = json.load(json_file)
 
         return self._conf
+
+    @property
+    def region(self):
+        # Use environment region if among available regions.
+        # Otherwise, default to first available region listed.
+        env_region = os.environ.get("AWS_REGION")
+        if env_region in self.conf["table"]["available_regions"]:
+            return env_region
+        return self.conf["table"]["available_regions"][0]
 
     def handler(self, event, context):
         raise NotImplementedError

--- a/exodus_lambda/functions/origin_request.py
+++ b/exodus_lambda/functions/origin_request.py
@@ -19,9 +19,7 @@ class OriginRequest(LambdaBase):
     @property
     def db_client(self):
         if not self._db_client:
-            self._db_client = boto3.client(
-                "dynamodb", region_name=self.conf["table"]["region"]
-            )
+            self._db_client = boto3.client("dynamodb", region_name=self.region)
 
         return self._db_client
 

--- a/tests/functions/test_base.py
+++ b/tests/functions/test_base.py
@@ -2,9 +2,31 @@ import pytest
 
 from exodus_lambda.functions.base import LambdaBase
 
-CONF_PATH = "exodus_lambda/functions/lambda_config.json"
+CONF_PATH = "configuration/lambda_config.json"
 
 
-def test_base():
+def test_base_handler():
     with pytest.raises(NotImplementedError):
         LambdaBase(conf_file=CONF_PATH).handler(event=None, context=None)
+
+
+@pytest.mark.parametrize(
+    "env_var,exp_var",
+    [
+        ("us-south-7", "us-east-1"),
+        ("ap-southeast-2", "ap-southeast-2"),
+        ("ap-northeast-3", "us-east-1"),
+    ],
+    ids=["fake", "available", "unavailable"],
+)
+def test_base_region(env_var, exp_var, monkeypatch):
+    """Ensure correct regions are selected for various inputs"""
+    base = LambdaBase(conf_file=CONF_PATH)
+
+    # Environment variable is set
+    monkeypatch.setenv("AWS_REGION", env_var)
+    assert base.region == exp_var
+
+    # Environment variable is unset
+    monkeypatch.delenv("AWS_REGION")
+    assert base.region == "us-east-1"


### PR DESCRIPTION
This commit adds a list of available AWS service endpoints (regions) to
lambda_config.json. The origin_request function will use the first of
the listed regions if an unavailable or invalid region is specified in
the environment variables.