### PR TITLE
Remove not_implemented function

### DIFF
--- a/exodus_lambda/functions/not_implemented.py
+++ b/exodus_lambda/functions/not_implemented.py
@@ -1,7 +1,0 @@
-def lambda_handler(event, context):
-    _ = event, context
-
-    return {
-        "status": "501",
-        "statusDescription": "Not Implemented",
-    }

--- a/tests/functions/test_not_implemented.py
+++ b/tests/functions/test_not_implemented.py
@@ -1,5 +1,0 @@
-from exodus_lambda.functions.not_implemented import lambda_handler
-
-
-def test_lambda_handler():
-    assert lambda_handler({}, {})["status"] == "501"


### PR DESCRIPTION
The not_implemented function, which served as a placeholder function for
repository creation, no longer has a use.