### PR TITLE
Reduce AWS regions listed in lambda config [RHELDST-1067]

### DIFF
--- a/configuration/lambda_config.json
+++ b/configuration/lambda_config.json
@@ -2,12 +2,7 @@
   "table": {
     "name": "exodus-cdn-$ENV_TYPE",
     "available_regions": [
-      "us-east-1",
-      "us-west-1",
-      "ap-east-1",
-      "ap-south-1",
-      "ap-southeast-2",
-      "eu-central-1"
+      "us-east-1"
     ]
   },
   "headers": {

--- a/tests/functions/test_base.py
+++ b/tests/functions/test_base.py
@@ -25,7 +25,7 @@ def test_base_handler():
 )
 def test_base_region(env_var, exp_var, monkeypatch):
     """Ensure correct regions are selected for various inputs"""
-    base = LambdaBase(conf_file=CONF_PATH)
+    base = LambdaBase(conf_file=TEST_CONF)
 
     # Environment variable is set
     monkeypatch.setenv("AWS_REGION", env_var)

--- a/tests/test_utils/utils.py
+++ b/tests/test_utils/utils.py
@@ -4,10 +4,33 @@ import json
 def generate_test_config(conf="configuration/lambda_config.json"):
     with open(conf, "r") as json_file:
         conf = json.load(json_file)
+
+    # table
+    conf["table"]["name"] = "test-table"
+    conf["table"]["available_regions"] = [
+        "us-east-1",
+        "us-east-2",
+        "us-west-1",
+        "us-west-2",
+        "ca-central-1",
+        "eu-central-1",
+        "eu-west-2",
+        "eu-west-3",
+        "eu-west-1",
+        "sa-east-1",
+        "ap-south-1",
+        "ap-northeast-2",
+        "ap-southeast-1",
+        "ap-southeast-2",
+        "ap-northeast-1",
+    ]
+
+    # logging
     conf["logging"]["formatters"]["default"][
         "format"
     ] = "[%(levelname)s] - %(message)s\n"
     conf["logging"]["loggers"]["origin-response"]["level"] = "DEBUG"
     conf["logging"]["loggers"]["origin-request"]["level"] = "DEBUG"
     conf["logging"]["loggers"]["default"]["level"] = "DEBUG"
+
     return conf


### PR DESCRIPTION
This commit removes all regions listed, save for us-east-1, as this is
the only region in which tables are currently available.