### PR TITLE
Use real branch name in verify-source [RHELDST-1288]

### DIFF
--- a/configuration/exodus-pipeline.yaml
+++ b/configuration/exodus-pipeline.yaml
@@ -186,7 +186,7 @@ Resources:
                       !Sub '[
                         {"name": "REPO_OWNER", "value": "${repoOwner}", "type": "PLAINTEXT"},
                         {"name": "REPO_NAME", "value": "${repoName}", "type": "PLAINTEXT"},
-                        {"name": "REPO_BRANCH", "value": "${repoBranch}", "type": "PLAINTEXT"},
+                        {"name": "REPO_BRANCH", "value": "#{SourceVars.BranchName}", "type": "PLAINTEXT"},
                         {"name": "COMMIT_ID", "value": "#{SourceVars.CommitId}", "type": "PLAINTEXT"},
                         {"name": "PROJECT", "value": "${project}", "type": "PLAINTEXT"}
                       ]'


### PR DESCRIPTION
This commit changes verify-source's REPO_BRANCH variable to the branch
name from the source stage rather than the template parameter value.

This resolves an issue wherein no branch is specified by the user,
preferring to instead use the template's default values, and an attempt
to checkout "None" as a branch is made.