### PR TITLE
Add CodePipelineBucket to CodePipeline dependencies [RHELDST-1291]

### DIFF
--- a/configuration/exodus-pipeline.yaml
+++ b/configuration/exodus-pipeline.yaml
@@ -263,6 +263,7 @@ Resources:
           - !Ref AWS::NoValue
     DependsOn:
       - CodePipelineRole
+      - CodePipelineBucket
       - CloudFormationRole
 
   CodePipelineEventRule:


### PR DESCRIPTION
This commit adds CodePipelineBucket resource to CodePipeline resource's
DependsOn attribute, as CloudFormation may otherwise attempt to create
the pipeline before its artifact bucket exists.