### PR TITLE
[RHELDST-1339] Use base64-encoded sha256sum in integration test

### DIFF
--- a/tests/integration/test_exodus.py
+++ b/tests/integration/test_exodus.py
@@ -49,7 +49,7 @@ def test_header_want_digest_GET(cdn_test_url):
     assert r.status_code == 200
     assert (
         r.headers["digest"]
-        == "id-sha-256=b51f4ddc06fddec9e73892671f1f25300ccd4235fa798afd01caf96446dc2bf1"
+        == "id-sha-256=tR9N3Ab93snnOJJnHx8lMAzNQjX6eYr9Acr5ZEbcK/E="
     )
 
 
@@ -60,7 +60,7 @@ def test_header_want_digest_HEAD(cdn_test_url):
     assert r.status_code == 200
     assert (
         r.headers["digest"]
-        == "id-sha-256=b51f4ddc06fddec9e73892671f1f25300ccd4235fa798afd01caf96446dc2bf1"
+        == "id-sha-256=tR9N3Ab93snnOJJnHx8lMAzNQjX6eYr9Acr5ZEbcK/E="
     )
 
 


### PR DESCRIPTION
1. It's a bug in integration test
2. The test-want-digest integration tests should use base64-encoded sha256sums,
rather than non-base64-encoded sha256sums.