### PR TITLE
Reorganize pipeline resources [RHELDST-1363]

### DIFF
--- a/configuration/exodus-pipeline-resources.yaml
+++ b/configuration/exodus-pipeline-resources.yaml
@@ -1,0 +1,221 @@
+AWSTemplateFormatVersion: 2010-09-09
+
+Description: Configuration for exodus-cdn CodePipeline
+
+Parameters:
+  region:
+    Type: String
+    Default: us-east-1
+    Description: The region in which resources are established
+  project:
+    Type: String
+    Default: exodus
+    Description: The project name under which resources are created
+  useCloudTrail:
+    Type: String
+    AllowedValues:
+      - true
+      - false
+    Default: false
+    Description: Determines whether to create CloudTrail resources
+  codebuildrole:
+    Type: String
+    Default: None
+    Description: The IAM Role ARN for CodeBuild resource
+
+Conditions:
+  CreateCloudTrail:
+    !Equals [!Ref useCloudTrail, true]
+
+Resources:
+  CodePipelineCloudTrail:
+    Type: AWS::CloudTrail::Trail
+    # Create trail for prod pipeline
+    Condition: CreateCloudTrail
+    Properties:
+      S3BucketName: !Sub ${project}-cloudtrail-logs
+      EventSelectors:
+        - DataResources:
+          - Type: AWS::S3::Object
+            Values:
+              - "arn:aws:s3:::"
+          ReadWriteType: WriteOnly
+          IncludeManagementEvents: false
+      IsLogging: true
+    DependsOn: CloudTrailBucketPolicy
+
+  CodePipelineBucket:
+    Type: AWS::S3::Bucket
+    # Create artifact bucket for dev pipeline
+    Properties:
+      BucketName: !Sub ${project}-pipeline-artifacts
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      VersioningConfiguration:
+        Status: Enabled
+    DeletionPolicy: Retain
+
+  CodePipelineBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    # Create artifact bucket policy for dev pipeline
+    Properties:
+      Bucket: !Sub ${project}-pipeline-artifacts
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: "s3:*"
+            Principal:
+              Service:
+                - s3.amazonaws.com
+            Resource: !Sub arn:aws:s3:::${project}-pipeline-artifacts
+    DependsOn: CodePipelineBucket
+
+  CloudTrailBucket:
+    Type: AWS::S3::Bucket
+    # Create bucket for cloudtrail logs
+    Condition: CreateCloudTrail
+    Properties:
+      BucketName: !Sub ${project}-cloudtrail-logs
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      LifecycleConfiguration:
+        Rules:
+          - Status: "Enabled"
+            ExpirationInDays: 1
+
+  CloudTrailBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    #Create bucket policy for cloudtrail logs
+    Condition: CreateCloudTrail
+    Properties:
+      Bucket: !Sub ${project}-cloudtrail-logs
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - cloudtrail.amazonaws.com
+            Action: s3:GetBucketAcl
+            Resource: !Sub arn:aws:s3:::${project}-cloudtrail-logs
+          - Effect: Allow
+            Principal:
+              Service:
+                - cloudtrail.amazonaws.com
+            Action: s3:PutObject
+            Resource: !Sub arn:aws:s3:::${project}-cloudtrail-logs/AWSLogs/${AWS::AccountId}/*
+            Condition:
+              StringEquals:
+                s3:x-amz-acl: bucket-owner-full-control
+
+  VerifySourceProject:
+    Type: AWS::CodeBuild::Project
+    # Create verify source project for stage pipeline
+    Properties:
+      Name: !Sub ${project}-verify-source
+      ServiceRole: !Sub ${codebuildrole}
+      Environment:
+        Type: LINUX_CONTAINER
+        ComputeType: BUILD_GENERAL1_SMALL
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:2.0
+      Source:
+        Type: NO_SOURCE
+        BuildSpec: |
+          version: 0.2
+          phases:
+            build:
+              commands:
+                - aws s3 cp s3://$PROJECT-pipeline-artifacts/.whitelist.gpg .whitelist.gpg
+                - gpg --import .whitelist.gpg
+                - git clone https://github.com/$REPO_OWNER/$REPO_NAME.git -b $REPO_BRANCH
+                - cd ./$REPO_NAME
+                - git verify-tag $(git describe --exact-match $COMMIT_ID)
+                - aws s3 cp .whitelist.gpg s3://$PROJECT-pipeline-artifacts/.whitelist.gpg
+      Artifacts:
+        Type: NO_ARTIFACTS
+      TimeoutInMinutes: 10
+
+  LambdaBuildProject:
+    Type: AWS::CodeBuild::Project
+    # Create CodeBuild project for dev pipeline
+    Properties:
+      Name: !Sub ${project}-lambda-build
+      ServiceRole: !Sub ${codebuildrole}
+      Environment:
+        Type: LINUX_CONTAINER
+        ComputeType: BUILD_GENERAL1_SMALL
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:2.0
+      Source:
+        Type: CODEPIPELINE
+        BuildSpec: |
+          version: 0.2
+          phases:
+            build:
+              commands:
+                - ./scripts/build-package
+          artifacts:
+            files:
+              - ./package/exodus-lambda-pkg.yaml
+            discard-paths: yes
+      Artifacts:
+        Type: CODEPIPELINE
+      TimeoutInMinutes: 10
+
+  IntegrationTestsProject:
+    Type: AWS::CodeBuild::Project
+    # Create CodeBuild project for running integration tests against the pipeline
+    Properties:
+      Name: !Sub ${project}-integration-tests
+      ServiceRole: !Sub ${codebuildrole}
+      Environment:
+        Type: LINUX_CONTAINER
+        ComputeType: BUILD_GENERAL1_SMALL
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+      Source:
+        Type: CODEPIPELINE
+        BuildSpec: |
+          version: 0.2
+          phases:
+            install:
+              runtime-versions:
+                python: 3.7
+              commands:
+                - pip install --upgrade pip
+                - pip install tox
+            build:
+              commands:
+                - tox -e integration-tests
+      Artifacts:
+        Type: CODEPIPELINE
+      TimeoutInMinutes: 15
+
+  RollbackProject:
+    Type: AWS::CodeBuild::Project
+    # Create CodeBuild project for re-deploying the last successful lambda stack
+    Properties:
+      Name: !Sub ${project}-rollback
+      ServiceRole: !Sub ${codebuildrole}
+      Environment:
+        Type: LINUX_CONTAINER
+        ComputeType: BUILD_GENERAL1_SMALL
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:2.0
+      Source:
+        Type: NO_SOURCE
+        BuildSpec: |
+          version: 0.2
+          phases:
+            build:
+              commands:
+                - aws s3 cp s3://$PROJECT-pipeline-artifacts/build-$ENV_TYPE .
+                - unzip build-$ENV_TYPE
+                - aws cloudformation deploy --template-file exodus-lambda-pkg.yaml --capabilities CAPABILITY_NAMED_IAM --stack-name $PROJECT-lambda-$ENV_TYPE --parameter-overrides env=$ENV_TYPE project=$PROJECT oai=$OAI
+      Artifacts:
+        Type: NO_ARTIFACTS
+      TimeoutInMinutes: 10

--- a/configuration/exodus-pipeline.yaml
+++ b/configuration/exodus-pipeline.yaml
@@ -41,17 +41,6 @@ Parameters:
     Type: String
     Default: exodus
     Description: The project name under which resources are created
-  useCloudTrail:
-    Type: String
-    AllowedValues:
-      - true
-      - false
-    Default: false
-    Description: Determines whether to create CloudTrail resources
-  codebuildrole:
-    Type: String
-    Default: None
-    Description: The IAM Role ARN for CodeBuild resource
   cloudformationrole:
     Type: String
     Default: None
@@ -80,8 +69,6 @@ Conditions:
     !Not [!Equals [!Ref env, prod]]
   NoBranch:
     !Equals [!Ref repoBranch, None]
-  CreateCloudTrail:
-    !And [!Condition IsProd, !Equals [!Ref useCloudTrail, true]]
 
 Resources:
   SNSTopic:
@@ -332,204 +319,6 @@ Resources:
           RoleArn: !Sub ${cloudwatcheventrole}
           Id: !Ref CodePipeline
 
-  CodePipelineCloudTrail:
-    Type: AWS::CloudTrail::Trail
-    # Create trail for prod pipeline
-    Condition: CreateCloudTrail
-    Properties:
-      S3BucketName: !Sub ${project}-cloudtrail-logs
-      EventSelectors:
-        - DataResources:
-          - Type: AWS::S3::Object
-            Values:
-              - "arn:aws:s3:::"
-          ReadWriteType: WriteOnly
-          IncludeManagementEvents: false
-      IsLogging: true
-    DependsOn: CloudTrailBucketPolicy
-
-  CodePipelineBucket:
-    Type: AWS::S3::Bucket
-    # Create artifact bucket for dev pipeline
-    Condition: IsDev
-    Properties:
-      BucketName: !Sub ${project}-pipeline-artifacts
-      PublicAccessBlockConfiguration:
-        BlockPublicAcls: true
-        BlockPublicPolicy: true
-        IgnorePublicAcls: true
-        RestrictPublicBuckets: true
-      VersioningConfiguration:
-        Status: Enabled
-
-  CodePipelineBucketPolicy:
-    Type: AWS::S3::BucketPolicy
-    # Create artifact bucket policy for dev pipeline
-    Condition: IsDev
-    Properties:
-      Bucket: !Sub ${project}-pipeline-artifacts
-      PolicyDocument:
-        Version: 2012-10-17
-        Statement:
-          - Effect: Allow
-            Action: "s3:*"
-            Principal:
-              Service:
-                - s3.amazonaws.com
-            Resource: !Sub arn:aws:s3:::${project}-pipeline-artifacts
-    DependsOn: CodePipelineBucket
-
-  CloudTrailBucket:
-    Type: AWS::S3::Bucket
-    # Create bucket for cloudtrail logs
-    Condition: CreateCloudTrail
-    Properties:
-      BucketName: !Sub ${project}-cloudtrail-logs
-      PublicAccessBlockConfiguration:
-        BlockPublicAcls: true
-        BlockPublicPolicy: true
-        IgnorePublicAcls: true
-        RestrictPublicBuckets: true
-      LifecycleConfiguration:
-        Rules:
-          - Status: "Enabled"
-            ExpirationInDays: 1
-
-  CloudTrailBucketPolicy:
-    Type: AWS::S3::BucketPolicy
-    #Create bucket policy for cloudtrail logs
-    Condition: CreateCloudTrail
-    Properties:
-      Bucket: !Sub ${project}-cloudtrail-logs
-      PolicyDocument:
-        Version: 2012-10-17
-        Statement:
-          - Effect: Allow
-            Principal:
-              Service:
-                - cloudtrail.amazonaws.com
-            Action: s3:GetBucketAcl
-            Resource: !Sub arn:aws:s3:::${project}-cloudtrail-logs
-          - Effect: Allow
-            Principal:
-              Service:
-                - cloudtrail.amazonaws.com
-            Action: s3:PutObject
-            Resource: !Sub arn:aws:s3:::${project}-cloudtrail-logs/AWSLogs/${AWS::AccountId}/*
-            Condition:
-              StringEquals:
-                s3:x-amz-acl: bucket-owner-full-control
-    DependsOn: CloudTrailBucket
-
-  VerifySourceProject:
-    Type: AWS::CodeBuild::Project
-    # Create verify source project for stage pipeline
-    Condition: IsStage
-    Properties:
-      Name: !Sub ${project}-verify-source
-      ServiceRole: !Sub ${codebuildrole}
-      Environment:
-        Type: LINUX_CONTAINER
-        ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/amazonlinux2-x86_64-standard:2.0
-      Source:
-        Type: NO_SOURCE
-        BuildSpec: |
-          version: 0.2
-          phases:
-            build:
-              commands:
-                - aws s3 cp s3://$PROJECT-pipeline-artifacts/.whitelist.gpg .whitelist.gpg
-                - gpg --import .whitelist.gpg
-                - git clone https://github.com/$REPO_OWNER/$REPO_NAME.git -b $REPO_BRANCH
-                - cd ./$REPO_NAME
-                - git verify-tag $(git describe --exact-match $COMMIT_ID)
-                - aws s3 cp .whitelist.gpg s3://$PROJECT-pipeline-artifacts/.whitelist.gpg
-      Artifacts:
-        Type: NO_ARTIFACTS
-      TimeoutInMinutes: 10
-
-  LambdaBuildProject:
-    Type: AWS::CodeBuild::Project
-    # Create CodeBuild project for dev pipeline
-    Condition: IsDev
-    Properties:
-      Name: !Sub ${project}-lambda-build
-      ServiceRole: !Sub ${codebuildrole}
-      Environment:
-        Type: LINUX_CONTAINER
-        ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/amazonlinux2-x86_64-standard:2.0
-      Source:
-        Type: CODEPIPELINE
-        BuildSpec: |
-          version: 0.2
-          phases:
-            build:
-              commands:
-                - ./scripts/build-package
-          artifacts:
-            files:
-              - ./package/exodus-lambda-pkg.yaml
-            discard-paths: yes
-      Artifacts:
-        Type: CODEPIPELINE
-      TimeoutInMinutes: 10
-
-  IntegrationTestsProject:
-    Type: AWS::CodeBuild::Project
-    Condition: IsDev
-    # Create CodeBuild project for running integration tests against the pipeline
-    Properties:
-      Name: !Sub ${project}-integration-tests
-      ServiceRole: !Sub ${codebuildrole}
-      Environment:
-        Type: LINUX_CONTAINER
-        ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
-      Source:
-        Type: CODEPIPELINE
-        BuildSpec: |
-          version: 0.2
-          phases:
-            install:
-              runtime-versions:
-                python: 3.7
-              commands:
-                - pip install --upgrade pip
-                - pip install tox
-            build:
-              commands:
-                - tox -e integration-tests
-      Artifacts:
-        Type: CODEPIPELINE
-      TimeoutInMinutes: 15
-
-  RollbackProject:
-    Type: AWS::CodeBuild::Project
-    Condition: IsDev
-    # Create CodeBuild project for re-deploying the last successful lambda stack
-    Properties:
-      Name: !Sub ${project}-rollback
-      ServiceRole: !Sub ${codebuildrole}
-      Environment:
-        Type: LINUX_CONTAINER
-        ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/amazonlinux2-x86_64-standard:2.0
-      Source:
-        Type: NO_SOURCE
-        BuildSpec: |
-          version: 0.2
-          phases:
-            build:
-              commands:
-                - aws s3 cp s3://$PROJECT-pipeline-artifacts/build-$ENV_TYPE .
-                - unzip build-$ENV_TYPE
-                - aws cloudformation deploy --template-file exodus-lambda-pkg.yaml --capabilities CAPABILITY_NAMED_IAM --stack-name $PROJECT-lambda-$ENV_TYPE --parameter-overrides env=$ENV_TYPE project=$PROJECT oai=$OAI
-      Artifacts:
-        Type: NO_ARTIFACTS
-      TimeoutInMinutes: 10
-
   RollbackEventRule:
     Type: AWS::Events::Rule
     # Create event rule for rollback
@@ -564,12 +353,6 @@ Outputs:
   CodePipeline:
     Description: exodus pipeline name
     Value: !Ref CodePipeline
-  CodePipelineBucket:
-    Description: exodus pipeline artifact bucket ARN
-    Value: !Sub arn:aws:s3:::${project}-pipeline-artifacts
-  LambdaBuildProject:
-    Description: exodus CodeBuild project ARN
-    Value: !Sub arn:aws:codebuild:${region}:${AWS::AccountId}:project/${project}-lambda-build
   SNSTopic:
     Description: exodus SNS topic ARN
     Value: !Ref SNSTopic


### PR DESCRIPTION
This commit groups all pipeline resources which are not env-dependent
into a separate template. This avoids arbitrarily grouping such resources
in env-specific pipeline stacks.