### PR TITLE
Parameterize origin access identity in exodus-storage [RHELDST-1325]

### DIFF
--- a/configuration/exodus-storage.yaml
+++ b/configuration/exodus-storage.yaml
@@ -15,6 +15,9 @@ Parameters:
     Type: String
     Default: exodus
     Description: The project name under which resources are created
+  oai:
+    Type: String
+    Description: The origin access identity ID associated with the environment
 
 Resources:
   Table:
@@ -66,13 +69,7 @@ Resources:
                   - !GetAtt Bucket.Arn
                   - "/*"
             Principal:
-              CanonicalUser: !GetAtt OriginAccessIdentity.S3CanonicalUserId
-
-  OriginAccessIdentity:
-    Type: AWS::CloudFront::CloudFrontOriginAccessIdentity
-    Properties:
-      CloudFrontOriginAccessIdentityConfig:
-        Comment: !Sub ${project}-cdn-${env}
+              AWS: !Sub "arn:aws:iam::cloudfront:user/CloudFront Origin Access Identity ${oai}"
 
 Outputs:
   Table:


### PR DESCRIPTION
This commit removes the creation of the origin access identity, instead
requiring it as a parameter. This allows for use of exodus-storage.yaml
in exodus-lambda-playbooks.