### PR TITLE
docs: add details on publishing tools

### DIFF
--- a/docs/arch.gv
+++ b/docs/arch.gv
@@ -39,11 +39,18 @@ digraph {
     # in the request processing.
     # Connection order here is reversed to force the publishing tools to the bottom
     # of the graph, which makes them stand out a bit more.
-    S3 -> publish_tools [dir="back"]
-    db -> publish_tools [dir="back"]
+    S3:s -> exodus_gw:ne [dir="back"]
+    db:s -> exodus_gw:nw [dir="back"]
+
+    exodus_gw -> exodus_rsync:n [dir="back"];
+    exodus_gw -> native_tools:n [dir="back"];
+    exodus_rsync -> legacy_tools:n [dir="back"];
 
     client [label="client"]
-    publish_tools [label="publishing tools", style="rounded", rank="max", shape="box"]
+    exodus_gw [label="exodus-gw"];
+    exodus_rsync [label="exodus-rsync"];
+    legacy_tools [label="publishing tools (rsync)", style="dashed"];
+    native_tools [label="publishing tools (exodus)", style="dashed"];
 
     db [
         shape=plaintext
@@ -134,6 +141,20 @@ digraph {
             rank=same
             origin_request;
             origin_response;
+        }
+    }
+
+    subgraph cluster_10 {
+        label=< <b>publishing tools</b> >
+        style="dashed,rounded";
+        exodus_gw;
+        exodus_rsync;
+        subgraph cluster_11 {
+            label="";
+            style="invis";
+            rank=same;
+            legacy_tools;
+            native_tools;
         }
     }
 }

--- a/docs/arch.rst
+++ b/docs/arch.rst
@@ -103,15 +103,38 @@ origin_response
     For more information about this function's behavior, see
     :ref:`function_ref`.
 
-publishing tools
-    Represents the tools used by Red Hat to publish content onto the CDN.
+exodus-gw
+    A microservice dedicated to writing data onto the CDN, this component
+    exposes an HTTP API for use by publishing tools, and enforces certain
+    policies on published content.
 
-    These tools insert data into the CDN's S3 and DynamoDB services in order to
-    publish content.
+    It is the only component permitted to perform writes on DynamoDB and S3
+    (hence, the "exodus gateway").
 
-    A further explanation of these tools is out of scope for this document; it
-    suffices to know that the tools are designed with an awareness of the CDN
-    architecture described here.
+exodus-rsync
+    A drop-in replacement for the ``rsync`` command. This command has
+    an interface which is partially compatible with ``rsync``, but it
+    performs publishes via API calls to ``exodus-gw`` rather than using
+    the rsync protocol.
+
+    exodus-rsync is not fully rsync-compatible; it is engineered to support
+    specific known publishing tools designed for rsync.
+
+publishing tools (rsync)
+    Represents tools used by Red Hat to publish content onto the CDN which
+    are designed to use rsync and are mostly unaware of the Exodus CDN
+    architecture. These tools are made to publish to Exodus CDN by replacing
+    the ``rsync`` command with ``exodus-rsync``.
+
+    RHSM Pulp is an example of a publishing tool using rsync.
+
+publishing tools (exodus)
+    Represents tools used by Red Hat to publish content onto the CDN which
+    are explicitly designed for Exodus CDN.
+
+    These tools don't need to use the ``exodus-rsync`` compatibility layer,
+    and so may have improved performance or an extended feature set when
+    compared with tools using rsync.
 
 .. _Amazon CloudFront: https://aws.amazon.com/cloudfront/
 


### PR DESCRIPTION
We have a design for publishing tools now. Let's add them into the
architecture page so it's easier to see how everything fits
together.

exodus-gw, exodus-rsync repos don't exist yet; they should be
linked here once created.

It has been assumed that S3 uploads will be handled by exodus-gw,
but in truth this is still an open question; the diagram shows
the intended design and there is a chance that the plan will
change.