### PR TITLE
Remove origin function alarms from deployment template

### DIFF
--- a/configuration/exodus-lambda-deploy.yaml
+++ b/configuration/exodus-lambda-deploy.yaml
@@ -81,38 +81,6 @@ Resources:
       Timeout: 5
       AutoPublishAlias: live
 
-  OriginRequestAlarm:
-    Type: AWS::CloudWatch::Alarm
-    Properties:
-      AlarmName: !Sub ${project}-origin-request-alarm-${env}
-      AlarmDescription: !Sub ${project}-origin-request-${env} invocation errors
-      Namespace: AWS/Lambda
-      MetricName: Errors
-      Dimensions:
-        - Name: FunctionName
-          Value: !Ref OriginRequestFunc
-      Statistic: Sum
-      Period: 180
-      EvaluationPeriods: 1
-      ComparisonOperator: GreaterThanOrEqualToThreshold
-      Threshold: 3
-
-  OriginResponseAlarm:
-    Type: AWS::CloudWatch::Alarm
-    Properties:
-      AlarmName: !Sub ${project}-origin-response-alarm-${env}
-      AlarmDescription: !Sub ${project}-origin-response-${env} invocation errors
-      Namespace: AWS/Lambda
-      MetricName: Errors
-      Dimensions:
-        - Name: FunctionName
-          Value: !Ref OriginResponseFunc
-      Statistic: Sum
-      Period: 180
-      EvaluationPeriods: 1
-      ComparisonOperator: GreaterThanOrEqualToThreshold
-      Threshold: 3
-
 Outputs:
   Distribution:
     Description: distribution domain name
@@ -125,11 +93,3 @@ Outputs:
   OriginResponseFunc:
     Description: origin-response function ARN with version
     Value: !Ref OriginResponseFunc.Version
-
-  OriginRequestAlarm:
-    Description: origin-request function alarm ARN
-    Value: !GetAtt OriginRequestAlarm.Arn
-
-  OriginResponseAlarm:
-    Description: origin-response function alarm ARN
-    Value: !GetAtt OriginResponseAlarm.Arn


### PR DESCRIPTION
The CloudWatch alarms created by exodus-lambda-deploy/pkg.yaml are
neither used nor do we have plans to do so. This commit removes them
from the template, preventing the creation of wasted resources.