### PR TITLE
Remove versioning from CDN S3 buckets

### DIFF
--- a/configuration/exodus-storage.yaml
+++ b/configuration/exodus-storage.yaml
@@ -50,8 +50,6 @@ Resources:
         BlockPublicPolicy: true
         IgnorePublicAcls: true
         RestrictPublicBuckets: true
-      VersioningConfiguration:
-        Status: Enabled
 
   BucketPolicy:
     Type: AWS::S3::BucketPolicy


### PR DESCRIPTION
According to the current design, multiple object of the same key will
never be uploaded to the CDN S3 bucket, as the key is the sha256
checksum of the file. While probably harmless, leaving versioning
enabled can potentially hide duplicate uploads and drive up usage costs.

Closes #95