### PR TITLE
Execute tox with python 3.6 interperter

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
-envlist = py37, static, docs
+envlist = py36, py37, static, docs
+skip_missing_interpreters = true
 
 [testenv]
 deps=


### PR DESCRIPTION
Useful for boxes running python 3.6.
The tox execution is not failing if one of the interperters is missing