### PR TITLE
Restore origin access identity creation to exodus-storage [RHELDST-1325]

### DIFF
--- a/configuration/exodus-storage.yaml
+++ b/configuration/exodus-storage.yaml
@@ -15,9 +15,6 @@ Parameters:
     Type: String
     Default: exodus
     Description: The project name under which resources are created
-  oai:
-    Type: String
-    Description: The origin access identity ID associated with the environment
 
 Resources:
   Table:
@@ -67,7 +64,13 @@ Resources:
                   - !GetAtt Bucket.Arn
                   - "/*"
             Principal:
-              AWS: !Sub "arn:aws:iam::cloudfront:user/CloudFront Origin Access Identity ${oai}"
+              CanonicalUser: !GetAtt OriginAccessIdentity.S3CanonicalUserId
+
+  OriginAccessIdentity:
+    Type: AWS::CloudFront::CloudFrontOriginAccessIdentity
+    Properties:
+      CloudFrontOriginAccessIdentityConfig:
+        Comment: !Sub ${project}-cdn-${env}
 
 Outputs:
   Table:
@@ -77,3 +80,7 @@ Outputs:
   Bucket:
     Description: Created bucket
     Value: !Ref Bucket
+
+  OriginAccessIdentity:
+    Description: Created origin access identity
+    Value: !Ref OriginAccessIdentity


### PR DESCRIPTION
This commit returns the OriginAccessIdentity resource to the
exodus-storage stack template to eliminate the need for manual creation.

It was originally removed for Ansible support but an alternative solution
for Ansible use is preferred.