### PR TITLE
exodus-lambda requires cdn-definitions-private [RHELDST-4703]

### DIFF
--- a/configuration/exodus-pipeline.yaml
+++ b/configuration/exodus-pipeline.yaml
@@ -221,8 +221,11 @@ Resources:
                 Region: !Ref region
                 Configuration:
                   EnvironmentVariables:
-                    !Sub '[{"name": "ENV_TYPE", "value": "${env}", "type": "PLAINTEXT"},
-                    {"name": "PROJECT", "value": "${project}", "type": "PLAINTEXT"}]'
+                    !Sub '[
+                      {"name": "ENV_TYPE", "value": "${env}", "type": "PLAINTEXT"},
+                      {"name": "PROJECT", "value": "${project}", "type": "PLAINTEXT"},
+                      {"name": "GITHUB_TOKEN", "value": "${githubToken}", "type": "PLAINTEXT"}
+                    ]'
                   ProjectName: !Sub ${project}-lambda-build
                 InputArtifacts:
                   - Name: SourceArtifact

--- a/scripts/build-package
+++ b/scripts/build-package
@@ -3,6 +3,8 @@ set -e
 
 pip install --require-hashes -r requirements.txt --target ./package
 pip install --no-deps --target ./package .
+git clone git+https://${GITHUB_TOKEN}@github.com/release-engineering/cdn-definitions-private.git
+mv ./cdn-definitions-private/data.yaml ./package/cdn_definitions/data.yaml
 cp ./configuration/exodus-lambda-deploy.yaml ./package
 envsubst < ./configuration/lambda_config.json > ./package/lambda_config.json
 aws cloudformation package \


### PR DESCRIPTION
The configuration that was once available in the cdn-definitions
PyPI package has since moved to a private git repository:
"cdn-definitions-private".

In order for exodus-lambda to consume data from a private repo,
a "GITHUB_TOKEN" environment variable must be set. GITHUB_TOKEN
should be assigned a GitHub access token with the "repo" scope,
which enables clients (e.g., pip) access to private repos.