### PR TITLE
Replace deprecated cdn-definitions APIs

### DIFF
--- a/exodus_lambda/functions/origin_request.py
+++ b/exodus_lambda/functions/origin_request.py
@@ -3,15 +3,25 @@ import urllib
 from datetime import datetime, timezone
 
 import boto3
-from cdn_definitions import origin_aliases, rhui_aliases
+from cdn_definitions import load_data
 
 from .base import LambdaBase
 
 
 class OriginRequest(LambdaBase):
-    def __init__(self, conf_file="lambda_config.json"):
+    def __init__(
+        self, conf_file="lambda_config.json", definitions_source=None
+    ):
         super().__init__("origin-request", conf_file)
         self._db_client = None
+        self._definitions_source = definitions_source
+        self._definitions = None
+
+    @property
+    def definitions(self):
+        if self._definitions is None:
+            self._definitions = load_data(source=self._definitions_source)
+        return self._definitions
 
     @property
     def db_client(self):
@@ -35,8 +45,8 @@ class OriginRequest(LambdaBase):
             processed = []
 
             for alias in remaining:
-                if uri.startswith(alias.src + "/") or uri == alias.src:
-                    uri = uri.replace(alias.src, alias.dest, 1)
+                if uri.startswith(alias["src"] + "/") or uri == alias["src"]:
+                    uri = uri.replace(alias["src"], alias["dest"], 1)
                     processed.append(alias)
 
             if not processed:
@@ -52,12 +62,12 @@ class OriginRequest(LambdaBase):
 
     def resolve_aliases(self, uri):
         # aliases relating to origin, e.g. content/origin <=> origin
-        uri = self.uri_alias(uri, origin_aliases())
+        uri = self.uri_alias(uri, self.definitions.get("origin_alias"))
 
         # aliases relating to rhui; listing files are a special exemption
         # because they must be allowed to differ for rhui vs non-rhui.
         if not uri.endswith("/listing"):
-            uri = self.uri_alias(uri, rhui_aliases())
+            uri = self.uri_alias(uri, self.definitions.get("rhui_alias"))
 
         return uri
 

--- a/tests/functions/test_alias.py
+++ b/tests/functions/test_alias.py
@@ -15,7 +15,10 @@ def test_alias_single():
 
     req = OriginRequest(CONF_PATH)
 
-    aliases = [Alias("/foo/bar", ""), Alias("/baz", "/quux")]
+    aliases = [
+        {"src": "/foo/bar", "dest": ""},
+        {"src": "/baz", "dest": "/quux"},
+    ]
 
     # Only the first layer of /foo/bar ends up being resolved.
     assert (
@@ -29,7 +32,7 @@ def test_alias_boundary():
 
     req = OriginRequest(CONF_PATH)
 
-    aliases = [Alias("/foo/bar", "/")]
+    aliases = [{"src": "/foo/bar", "dest": "/"}]
 
     # /foo/bar should not be resolved since it's not followed by /.
     assert req.uri_alias("/foo/bar-somefile", aliases) == "/foo/bar-somefile"
@@ -40,6 +43,6 @@ def test_alias_equal():
 
     req = OriginRequest(CONF_PATH)
 
-    aliases = [Alias("/foo/bar", "/quux")]
+    aliases = [{"src": "/foo/bar", "dest": "/quux"}]
 
     assert req.uri_alias("/foo/bar", aliases) == "/quux"

--- a/tests/functions/test_origin_request.py
+++ b/tests/functions/test_origin_request.py
@@ -6,7 +6,7 @@ import pytest
 
 import mock
 from exodus_lambda.functions.origin_request import OriginRequest
-from test_utils.utils import generate_test_config
+from test_utils.utils import generate_test_config, mock_definitions
 
 TEST_PATH = "/origin/rpms/repo/ver/dir/filename.ext"
 MOCKED_DT = "2020-02-17T15:38:05.864+00:00"
@@ -88,9 +88,9 @@ def test_origin_request(
     event = {"Records": [{"cf": {"request": {"uri": req_uri, "headers": {}}}}]}
 
     with caplog.at_level(logging.DEBUG):
-        request = OriginRequest(conf_file=TEST_CONF).handler(
-            event, context=None
-        )
+        request = OriginRequest(
+            conf_file=TEST_CONF, definitions_source=mock_definitions()
+        ).handler(event, context=None)
 
     assert "Item found for '%s'" % real_uri in caplog.text
 
@@ -116,9 +116,9 @@ def test_origin_request_no_item(mocked_datetime, mocked_boto3_client, caplog):
     event = {"Records": [{"cf": {"request": {"uri": TEST_PATH}}}]}
 
     with caplog.at_level(logging.DEBUG):
-        request = OriginRequest(conf_file=TEST_CONF).handler(
-            event, context=None
-        )
+        request = OriginRequest(
+            conf_file=TEST_CONF, definitions_source=mock_definitions()
+        ).handler(event, context=None)
 
     assert request == {"status": "404", "statusDescription": "Not Found"}
     assert "No item found for '%s'" % TEST_PATH in caplog.text
@@ -142,9 +142,9 @@ def test_origin_request_invalid_item(
     event = {"Records": [{"cf": {"request": {"uri": TEST_PATH}}}]}
 
     with pytest.raises(KeyError):
-        request = OriginRequest(conf_file=TEST_CONF).handler(
-            event, context=None
-        )
+        request = OriginRequest(
+            conf_file=TEST_CONF, definitions_source=mock_definitions()
+        ).handler(event, context=None)
 
     assert (
         "Exception occurred while processing %s"

--- a/tests/test_data/data.yaml
+++ b/tests/test_data/data.yaml
@@ -1,0 +1,13 @@
+---
+version: "1.1.0"
+
+rhui_alias:
+- src: /content/dist/rhel/rhui
+  dest: /content/dist/rhel
+
+origin_alias:
+- src: /content/origin
+  dest: /origin
+
+- src: /origin/rpm
+  dest: /origin/rpms

--- a/tests/test_utils/utils.py
+++ b/tests/test_utils/utils.py
@@ -1,3 +1,4 @@
+import os
 import json
 
 
@@ -34,3 +35,9 @@ def generate_test_config(conf="configuration/lambda_config.json"):
     conf["logging"]["loggers"]["default"]["level"] = "DEBUG"
 
     return conf
+
+
+def mock_definitions():
+    return os.path.join(
+        os.path.dirname(os.path.dirname(__file__)), "test_data", "data.yaml"
+    )


### PR DESCRIPTION
The rhui_aliases and origin_aliases APIs were deprecated in
cdn-definitions-2.0.0. The deprecated APIs have been replaced with
the new load_data API.

When a source is not provided to load_data (or source=None), the data.yaml file packaged with cdn-definitions is used as the default data source.  https://github.com/release-engineering/exodus-lambda/pull/116 contains a change that overrides the packaged data.yaml file with the data.yaml file from cdn-definitions-private.
