### PR TITLE
build-package should install python-3.7 packages

### DIFF
--- a/scripts/build-package
+++ b/scripts/build-package
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -e
 
-pip install --require-hashes -r requirements.txt --target ./package
-pip install --no-deps --target ./package .
+python3.7 -m pip install --require-hashes -r requirements.txt --target ./package
+python3.7 -m pip install --no-deps --target ./package .
 git clone git+https://${GITHUB_TOKEN}@github.com/release-engineering/cdn-definitions-private.git
 mv ./cdn-definitions-private/data.yaml ./package/cdn_definitions/data.yaml
 cp ./configuration/exodus-lambda-deploy.yaml ./package


### PR DESCRIPTION
The CodeBuild project currently builds the exodus-lambda package with
amazonlinux's default Python version, Python 3.8. Our Lambda functions
use the Python 3.7 runtime. The exodus-lambda package should instead
be built with Python 3.7.