### PR TITLE
Run Lambda CodeBuild project with python3.7

### DIFF
--- a/configuration/exodus-pipeline-resources.yaml
+++ b/configuration/exodus-pipeline-resources.yaml
@@ -151,6 +151,11 @@ Resources:
         BuildSpec: |
           version: 0.2
           phases:
+            install:
+              runtime-versions:
+                python: 3.7
+              commands:
+                - pip install --upgrade pip
             build:
               commands:
                 - ./scripts/build-package


### PR DESCRIPTION
Adds an install phase, similiar to that of the IntegrationTestsProject,
to LambdaBuildProject. The install phase specifies python3.7 as the
runtime version and upgrades pip prior to the build phase which runs
the build-package script.