### PR TITLE
Change LambdaBuildProject image in pipeline resources

### DIFF
--- a/configuration/exodus-pipeline-resources.yaml
+++ b/configuration/exodus-pipeline-resources.yaml
@@ -145,7 +145,7 @@ Resources:
       Environment:
         Type: LINUX_CONTAINER
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/amazonlinux2-x86_64-standard:2.0
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
       Source:
         Type: CODEPIPELINE
         BuildSpec: |


### PR DESCRIPTION
When specifying the python3.7 runtime in #123, the environment image was
overlooked. The previous image, amazonlinux2:2.0 does not have python3.7
available, only 3.8. However, as evidenced by the
IntegrationTestsProject, amazonlinux2:3.0 does have python3.7. So,
change the image used for the LambdaBuildProject to the 3.0 tag.