### PR TITLE
Fix git clone command [RHELDST-4703]

### DIFF
--- a/scripts/build-package
+++ b/scripts/build-package
@@ -3,7 +3,7 @@ set -e
 
 pip install --require-hashes -r requirements.txt --target ./package
 pip install --no-deps --target ./package .
-git clone git+https://${GITHUB_TOKEN}@github.com/release-engineering/cdn-definitions-private.git
+git clone https://${GITHUB_TOKEN}@github.com/release-engineering/cdn-definitions-private.git
 mv ./cdn-definitions-private/data.yaml ./package/cdn_definitions/data.yaml
 cp ./configuration/exodus-lambda-deploy.yaml ./package
 envsubst < ./configuration/lambda_config.json > ./package/lambda_config.json


### PR DESCRIPTION
The 'git+' prefix is unnecessary and breaks the clone.