### PR TITLE
Prevent merge CI failures when docs haven't changed

### DIFF
--- a/scripts/push-docs
+++ b/scripts/push-docs
@@ -30,6 +30,13 @@ if enabled; then
 fi
 
 git add -A .
+
+if git diff --cached --quiet; then
+  # zero exit from git diff means nothing changed.
+  echo "No changes to docs, bailing out"
+  exit 0
+fi
+
 git commit -m "Build documentation for ${version} at ${rev}"
 
 if enabled; then


### PR DESCRIPTION
Changes push-docs script to bail out when no changes were made to
documentation before attempting to push to gh-pages branch.