### PR TITLE
docs: fix generated diagrams on github pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
 
     - name: Install dependencies
       run: |
+        sudo apt install graphviz
         python -m pip install -U pip
         pip install tox
 


### PR DESCRIPTION
Diagrams have been unable to render since graphviz ("dot" command)
was not installed. This was probably broken when we moved to github
actions. Since it's not a Python dependency, it needs a special
installation step and can't be covered by tox/requirements.txt/etc.