### PR TITLE
Consume cdn-definitions from table [RHELDST-7898]

### DIFF
--- a/configuration/lambda_config.json
+++ b/configuration/lambda_config.json
@@ -5,6 +5,13 @@
       "us-east-1"
     ]
   },
+  "config_table": {
+    "name": "$PROJECT-config-$ENV_TYPE",
+    "available_regions": [
+      "us-east-1"
+    ]
+  },
+  "config_cache_ttl": 2,
   "headers": {
     "max_age": "600"
   },

--- a/exodus_lambda/functions/base.py
+++ b/exodus_lambda/functions/base.py
@@ -17,8 +17,20 @@ class LambdaBase(object):
             if isinstance(self._conf_file, dict):
                 self._conf = self._conf_file
             else:
-                with open(self._conf_file, "r") as json_file:
-                    self._conf = json.load(json_file)
+                for conf_file in [
+                    self._conf_file,
+                    os.path.join(
+                        os.path.dirname(
+                            os.path.dirname(os.path.dirname(__file__))
+                        ),
+                        "configuration",
+                        "lambda_config.json",
+                    ),
+                ]:
+                    if os.path.exists(conf_file):
+                        with open(conf_file, "r") as json_file:
+                            self._conf = json.load(json_file)
+                        break
         return self._conf
 
     @property

--- a/requirements.in
+++ b/requirements.in
@@ -4,3 +4,4 @@ docutils
 cdn-definitions
 requests
 PyYAML
+cachetools

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,10 @@ botocore==1.21.17 \
     #   -r requirements.in
     #   boto3
     #   s3transfer
+cachetools==4.2.4 \
+    --hash=sha256:89ea6f1b638d5a73a4f9226be57ac5e4f399d22770b92355f92dcb0f7f001693 \
+    --hash=sha256:92971d3cb7d2a97efff7c7bb1657f21a8f5fb309a37530537c71b1774189f2d1
+    # via -r requirements.in
 cdn-definitions==2.1.0 \
     --hash=sha256:2d4438564435e50c9a1a2db4928d622a2c09453dc3942ca8eea9d8f98ee1977a
     # via -r requirements.in

--- a/scripts/build-package
+++ b/scripts/build-package
@@ -3,9 +3,6 @@ set -e
 
 pip install --require-hashes -r requirements.txt --target ./package
 pip install --no-deps --target ./package .
-git clone https://${GITHUB_TOKEN}@github.com/release-engineering/cdn-definitions-private.git
-mv ./cdn-definitions-private/data.yaml ./package/cdn_definitions/data.yaml
-cp ./configuration/exodus-lambda-deploy.yaml ./package
 envsubst < ./configuration/lambda_config.json > ./package/lambda_config.json
 aws cloudformation package \
 	--template ./package/exodus-lambda-deploy.yaml \

--- a/tests/functions/test_alias.py
+++ b/tests/functions/test_alias.py
@@ -3,7 +3,10 @@ from collections import namedtuple
 
 from exodus_lambda.functions.origin_request import OriginRequest
 
-CONF_PATH = "exodus_lambda/functions/lambda_config.json"
+from ..test_utils.utils import generate_test_config
+
+CONF_PATH = "configuration/lambda_config.json"
+TEST_CONF = generate_test_config(CONF_PATH)
 
 Alias = namedtuple("Alias", ["src", "dest"])
 
@@ -11,7 +14,7 @@ Alias = namedtuple("Alias", ["src", "dest"])
 def test_alias_single():
     """Each alias is only applied a single time."""
 
-    req = OriginRequest(CONF_PATH)
+    req = OriginRequest(conf_file=TEST_CONF)
 
     aliases = [
         {"src": "/foo/bar", "dest": ""},
@@ -28,7 +31,7 @@ def test_alias_single():
 def test_alias_boundary():
     """Aliases are only resolved at path boundaries."""
 
-    req = OriginRequest(CONF_PATH)
+    req = OriginRequest(conf_file=TEST_CONF)
 
     aliases = [{"src": "/foo/bar", "dest": "/"}]
 
@@ -39,7 +42,7 @@ def test_alias_boundary():
 def test_alias_equal():
     """Paths exactly matching an alias can be resolved."""
 
-    req = OriginRequest(CONF_PATH)
+    req = OriginRequest(conf_file=TEST_CONF)
 
     aliases = [{"src": "/foo/bar", "dest": "/quux"}]
 

--- a/tests/test_utils/utils.py
+++ b/tests/test_utils/utils.py
@@ -1,6 +1,8 @@
 import json
 import os
 
+from cdn_definitions import load_data
+
 
 def generate_test_config(conf="configuration/lambda_config.json"):
     with open(conf, "r") as json_file:
@@ -34,10 +36,17 @@ def generate_test_config(conf="configuration/lambda_config.json"):
     conf["logging"]["loggers"]["origin-request"]["level"] = "DEBUG"
     conf["logging"]["loggers"]["default"]["level"] = "DEBUG"
 
+    conf["config_table"]["name"] = "test-config-table"
+    conf["config_table"]["cache_ttl"] = 2
+
     return conf
 
 
 def mock_definitions():
-    return os.path.join(
-        os.path.dirname(os.path.dirname(__file__)), "test_data", "data.yaml"
+    return load_data(
+        os.path.join(
+            os.path.dirname(os.path.dirname(__file__)),
+            "test_data",
+            "data.yaml",
+        )
     )


### PR DESCRIPTION
The exodus-lambda functions previously consumed the cdn definitions
from the the exodus-lambda package. This workflow required the lambdas
to be rebuilt and redeployed after each update to the cdn-definitions
data set.

Release engineers should be able to update the cdn-definitions data
set without rebuilding and redeploying the lambdas. The definitions
are now stored in a $project-config-$env DynamoDB table, which is
decoupled from the exodus-lambda package.