### PR TITLE
exodus-lambda resolves releasever aliases [RHELDST-7901]

### DIFF
--- a/exodus_lambda/functions/origin_request.py
+++ b/exodus_lambda/functions/origin_request.py
@@ -95,6 +95,9 @@ class OriginRequest(LambdaBase):
         if not uri.endswith("/listing"):
             uri = self.uri_alias(uri, self.definitions.get("rhui_alias"))
 
+        # aliases relating to releasever; e.g. /content/dist/rhel8/8 <=> /content/dist/rhel8/8.5
+        uri = self.uri_alias(uri, self.definitions.get("releasever_alias"))
+
         return uri
 
     def handler(self, event, context):

--- a/support/reftest/data.yml
+++ b/support/reftest/data.yml
@@ -18,6 +18,9 @@ test_data:
 - path: /content/aus/rhel/server/6/6.5/x86_64/os/Packages/c/cpio-2.10-12.el6_5.x86_64.rpm
   sha256: 06316538b90d3aab20f4787132307f6d330da9a48bab11a13e0a616fcf622ce5
   content-type: application/x-rpm
+- path: /content/dist/rhel/server/6/6.10/x86_64/os/Packages/c/cpio-2.10-12.el6_5.x86_64.rpm
+  sha256: 06316538b90d3aab20f4787132307f6d330da9a48bab11a13e0a616fcf622ce5
+  content-type: application/x-rpm
 - path: /content/dist/rhel8/8.1/x86_64/baseos/os/Packages/i/iptables-1.8.2-16.el8.x86_64.rpm
   sha256: 580d8c304c0fce98a47cf0283849e5e9f7e8f5c7bda766921249765046947e40
   content-type: application/x-rpm
@@ -35,4 +38,6 @@ test_data:
   content-type: text/plain
 # */ostree/repo/refs/heads/*/* unstable content skip checksum-verify
 - path: /content/dist/rhel/atomic/7/7Server/x86_64/ostree/repo/refs/heads/rhel-atomic-host/7/x86_64/standard
+  content-type: text/plain
+- path: /content/dist/rhel/atomic/7/7.9/x86_64/ostree/repo/refs/heads/rhel-atomic-host/7/x86_64/standard
   content-type: text/plain

--- a/tests/functions/test_origin_request.py
+++ b/tests/functions/test_origin_request.py
@@ -53,6 +53,16 @@ TEST_CONF = generate_test_config(CONF_PATH)
             "/origin/rpms/repo/ver/dir/filename.ext",
             "text/plain",
         ),
+        (
+            "/content/dist/rhel/server/7/7Server/test.ext",
+            "/content/dist/rhel/server/7/7.9/test.ext",
+            "text/plain",
+        ),
+        (
+            "/content/dist/rhel/rhui/server/7/7Server/file.ext",
+            "/content/dist/rhel/server/7/7.9/file.ext",
+            "text/plain",
+        ),
     ],
     ids=[
         "/origin/rpm/",
@@ -62,6 +72,8 @@ TEST_CONF = generate_test_config(CONF_PATH)
         "rhui listing exception",
         "multiple alias keywords",
         "no alias keywords",
+        "releasever alias",
+        "layered rhui, releasever alias",
     ],
 )
 @mock.patch("boto3.client")

--- a/tests/integration/test_exodus.py
+++ b/tests/integration/test_exodus.py
@@ -165,3 +165,22 @@ def test_rhui_path_alias_rhel8(cdn_test_url, testdata_path):
         r.headers["digest"]
         == "id-sha-256=WA2MMEwPzpikfPAoOEnl6ffo9ce9p2aSEkl2UEaUfkA="
     )
+
+
+testdata_releasever_alias_rhel6 = [
+    "/content/dist/rhel/server/6/6.10/x86_64/os/Packages/c/cpio-2.10-12.el6_5.x86_64.rpm",
+    "/content/dist/rhel/server/6/6Server/x86_64/os/Packages/c/cpio-2.10-12.el6_5.x86_64.rpm",
+]
+
+
+@pytest.mark.parametrize("testdata_path", testdata_releasever_alias_rhel6)
+def test_releasever_alias_rhel6(cdn_test_url, testdata_path):
+    headers = {"want-digest": "id-sha-256"}
+    url = cdn_test_url + testdata_path
+    r = requests.head(url, headers=headers)
+    print(json.dumps(dict(r.headers), indent=2))
+    assert r.status_code == 200
+    assert (
+        r.headers["digest"]
+        == "id-sha-256=BjFlOLkNOqsg9HhxMjB/bTMNqaSLqxGhPgphb89iLOU="
+    )

--- a/tests/test_data/data.yaml
+++ b/tests/test_data/data.yaml
@@ -11,3 +11,7 @@ origin_alias:
 
 - src: /origin/rpm
   dest: /origin/rpms
+
+releasever_alias:
+- src: /content/dist/rhel/server/7/7Server
+  dest: /content/dist/rhel/server/7/7.9


### PR DESCRIPTION
The releasever aliases are a collection of "src" to "dest" mappings
produced by exodus-config. Much like the origin and rhui aliases
resolved by the origin-request function, the origin-request lambda
translates requests for URIs prefixed with the releasever alias'
"src" value into a new URI prefixed by the corresponding "dest"
value.