### PR TITLE
Upgrade python from 3.7 to 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up Python 3.7
+    - name: Set up Python 3.9
       uses: actions/setup-python@v2
       with:
-        python-version: '3.7'
+        python-version: '3.9'
 
     - name: Install dependencies
       run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,9 +3,9 @@ repos:
     rev: 20.8b1
     hooks:
     - id: black
-      language_version: python3.7
+      language_version: python3.9
 -   repo: https://github.com/pycqa/isort/
     rev: 5.6.4
     hooks:
     - id: isort
-      language_version: python3.7
+      language_version: python3.9

--- a/configuration/exodus-lambda-deploy.yaml
+++ b/configuration/exodus-lambda-deploy.yaml
@@ -66,7 +66,7 @@ Resources:
       CodeUri:
       Handler: exodus_lambda.origin_request
       Role: !Sub ${lambdafunctionrole}
-      Runtime: python3.7
+      Runtime: python3.9
       Timeout: 5
       AutoPublishAlias: live
 
@@ -77,7 +77,7 @@ Resources:
       CodeUri:
       Handler: exodus_lambda.origin_response
       Role: !Sub ${lambdafunctionrole}
-      Runtime: python3.7
+      Runtime: python3.9
       Timeout: 5
       AutoPublishAlias: live
 

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.7
+python-3.9

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
         "Programming Language :: Python :: 3",
     ],
     install_requires=get_requirements(),
-    python_requires=">=3.7",
+    python_requires=">=3.9",
     project_urls={
         "Documentation": "https://release-engineering.github.io/exodus-lambda"
     },


### PR DESCRIPTION
Bumps the python version used in CI and for deployment. There are two
motivations behind this:

- 3.7 is getting a bit old and it's a good practice to upgrade the
  runtime periodically

- per [1], python 3.7 uses Amazon Linux 1, and 3.8 and later use Amazon
  Linux 2. However our CodeBuild already uses Amazon Linux 2 and has
  done for some time.

  That means we're using a significantly different OS when *building*
  the lambda vs *running* it. As long as we have only pure-python
  dependencies it doesn't seem to matter, but when experimenting with
  signed URLs I found that this tends to break the lambda if any
  dependency has a native component. This makes sense as a binary
  compiled on Amazon Linux 2 is not necessarily going to work on 1.

  So, we must ensure that the same OS is used during build time and
  run time. Bump to python 3.9 achieves that.

[1] https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html