### PR TITLE
README: revise badges, fix invalid markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,9 @@ exodus-lambda
 
 AWS Lambda functions for Red Hat's Content Delivery Network
 
-[![Build Status](https://github.com/release-engineering/exodus-lambda/actions/workflows/ci.yml/badge.svg?branch=master)
+![Build Status](https://github.com/release-engineering/exodus-lambda/actions/workflows/ci.yml/badge.svg?branch=master)
 [![Coverage Status](https://coveralls.io/repos/github/release-engineering/exodus-lambda/badge.svg?branch=master)](https://coveralls.io/github/release-engineering/exodus-lambda?branch=master)
-
-- [Source](https://github.com/release-engineering/exodus-lambda)
-- [Documentation](https://release-engineering.github.io/exodus-lambda/)
+[![Documentation](https://img.shields.io/website?label=docs&url=https%3A%2F%2Frelease-engineering.github.io%2Fexodus-lambda%2F)](https://release-engineering.github.io/exodus-lambda/)
 
 
 Development


### PR DESCRIPTION
A stray '[' character was left in the badges markdown which has been
bugging me for a long time. Fix it; while I'm at it, I'd like to try
folding the docs link into the badges and dropping the redundant Sources
link for a cleaner look.