### PR TITLE
exodus-lambda crashed when missing content-type in DynamoDB [RHELDST-…

### DIFF
--- a/exodus_lambda/functions/origin_request.py
+++ b/exodus_lambda/functions/origin_request.py
@@ -146,11 +146,16 @@ class OriginRequest(LambdaBase):
                 request["uri"] = (
                     "/" + query_result["Items"][0]["object_key"]["S"]
                 )
-                content_type = query_result["Items"][0]["content_type"]["S"]
-                if content_type:
-                    request["querystring"] = urllib.parse.urlencode(
-                        {"response-content-type": content_type}
-                    )
+                content_type = (
+                    query_result["Items"][0].get("content_type", {}).get("S")
+                )
+                if not content_type:
+                    # return "application/octet-stream" when content_type is empty
+                    content_type = "application/octet-stream"
+
+                request["querystring"] = urllib.parse.urlencode(
+                    {"response-content-type": content_type}
+                )
 
                 self.logger.info(
                     "The request value for origin_request end is '%s'",

--- a/support/reftest/data.yml
+++ b/support/reftest/data.yml
@@ -41,3 +41,4 @@ test_data:
   content-type: text/plain
 - path: /content/dist/rhel/atomic/7/7.9/x86_64/ostree/repo/refs/heads/rhel-atomic-host/7/x86_64/standard
   content-type: text/plain
+- path: /content/dist/rhel8/8.2/x86_64/baseos/iso/rhel-8.2-x86_64-boot.iso

--- a/support/reftest/reftest
+++ b/support/reftest/reftest
@@ -38,15 +38,20 @@ class DBHandler:
     ):
         if not from_date:
             from_date = self.default_from_date
-        return self.dynamodb.put_item(
+
+        item = {
+            "web_uri": {"S": web_uri},
+            "from_date": {"S": from_date},
+            "object_key": {"S": object_key},
+            "metadata": {"M": metadata},
+        }
+
+        if content_type:
+            item["content_type"] = {"S": content_type}
+
+        self.dynamodb.put_item(
             TableName=self.table,
-            Item={
-                "web_uri": {"S": web_uri},
-                "from_date": {"S": from_date},
-                "object_key": {"S": object_key},
-                "content_type": {"S": content_type},
-                "metadata": {"M": metadata},
-            },
+            Item=item,
         )
 
 
@@ -213,7 +218,7 @@ def prepare(db_client, s3_client, config, opt):
             item["path"],
             cdn_data_checksum,
             from_date=opt.release_date,
-            content_type=item["content-type"],
+            content_type=item.get("content-type", None),
         )
 
         # delete the NamedTemporaryFile

--- a/tests/integration/test_exodus.py
+++ b/tests/integration/test_exodus.py
@@ -184,3 +184,17 @@ def test_releasever_alias_rhel6(cdn_test_url, testdata_path):
         r.headers["digest"]
         == "id-sha-256=BjFlOLkNOqsg9HhxMjB/bTMNqaSLqxGhPgphb89iLOU="
     )
+
+
+testdata_no_content_type = [
+    "/content/dist/rhel8/8.2/x86_64/baseos/iso/rhel-8.2-x86_64-boot.iso"
+]
+
+
+@pytest.mark.parametrize("testdata_path", testdata_no_content_type)
+def test_no_content_type(cdn_test_url, testdata_path):
+    url = cdn_test_url + testdata_path
+    r = requests.get(url)
+    print(json.dumps(dict(r.headers), indent=2))
+    assert r.status_code == 200
+    assert r.headers["Content-Type"] == "application/octet-stream"


### PR DESCRIPTION
…8905]

When a client requests an item with no content_type set, the response
should include a Content-Type of "application/octet-stream".

Add a new test case cover the empty content_type scenario.