### PR TITLE
Update Python 3.7 -> 3.9 for tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37, static, docs
+envlist = py39, static, docs
 
 [testenv]
 deps=
@@ -55,7 +55,6 @@ commands=
     rm -rf ./package
 
 [testenv:integration-tests]
-envlist = py37
 passenv = *
 commands=
 	pytest ./tests/integration --lambda-stack {env:STACK_NAME} {posargs}


### PR DESCRIPTION
We expect exodus-lambda to be built and run with Python 3.9, so we
should be testing with the same version.