### PR TITLE
Remove listing data, references from integration tests

### DIFF
--- a/support/reftest/data.yml
+++ b/support/reftest/data.yml
@@ -28,10 +28,6 @@ test_data:
 - path: /origin/rpms/bash/4.4.19/8.el8_0/fd431d51/bash-4.4.19-8.el8_0.x86_64.rpm
   sha256: 4164ff2c0116d666578ba5e456ab03b88788dfb42fb93fc91b2c1da709d86686
   content-type: application/x-rpm
-# listing
-- path: /content/dist/rhel/server/5/5.7/listing
-  sha256: b51f4ddc06fddec9e73892671f1f25300ccd4235fa798afd01caf96446dc2bf1
-  content-type: text/plain
 # PULP_MANIFEST
 - path: /content/dist/rhel8/8.2/x86_64/baseos/iso/PULP_MANIFEST
   sha256: 2fb7a09fd67432ad7b7c95d24fe332827e24920347319c24bfef236cb0b72f19

--- a/tests/integration/test_exodus.py
+++ b/tests/integration/test_exodus.py
@@ -30,7 +30,6 @@ def test_header_not_exist_file(cdn_test_url):
 # Test data for exodus-lambda
 # serving repo entry points with appropriate cache headers
 testdata_cache_control_path = [
-    "/content/dist/rhel/server/5/5.7/listing",
     "/content/dist/rhel/server/7/7.2/x86_64/rhev-mgmt-agent/3/os/repodata/repomd.xml",
     "/content/dist/rhel/atomic/7/7Server/x86_64/ostree/repo/refs/heads/rhel-atomic-host/7/x86_64/standard",  # noqa: E501
 ]
@@ -47,25 +46,31 @@ def test_header_cache_control(cdn_test_url, testdata_path):
 
 def test_header_want_digest_GET(cdn_test_url):
     headers = {"want-digest": "id-sha-256"}
-    url = cdn_test_url + "/content/dist/rhel/server/5/5.7/listing"
+    url = (
+        cdn_test_url
+        + "/content/dist/rhel/server/7/7.2/x86_64/rhev-mgmt-agent/3/os/repodata/repomd.xml"
+    )
     r = requests.get(url, headers=headers)
     print(json.dumps(dict(r.headers), indent=2))
     assert r.status_code == 200
     assert (
         r.headers["digest"]
-        == "id-sha-256=tR9N3Ab93snnOJJnHx8lMAzNQjX6eYr9Acr5ZEbcK/E="
+        == "id-sha-256=hYGantfjJjDl4O5HesjPpwtIG2V5vWIuIOfuki9ThDk="
     )
 
 
 def test_header_want_digest_HEAD(cdn_test_url):
     headers = {"want-digest": "id-sha-256"}
-    url = cdn_test_url + "/content/dist/rhel/server/5/5.7/listing"
+    url = (
+        cdn_test_url
+        + "/content/dist/rhel/server/7/7.2/x86_64/rhev-mgmt-agent/3/os/repodata/repomd.xml"
+    )
     r = requests.head(url, headers=headers)
     print(json.dumps(dict(r.headers), indent=2))
     assert r.status_code == 200
     assert (
         r.headers["digest"]
-        == "id-sha-256=tR9N3Ab93snnOJJnHx8lMAzNQjX6eYr9Acr5ZEbcK/E="
+        == "id-sha-256=hYGantfjJjDl4O5HesjPpwtIG2V5vWIuIOfuki9ThDk="
     )
 
 


### PR DESCRIPTION
Listing files are no longer expected on CDN, as listings are now generated
upon request from exodus-config data on $project-config-$env tables.