### PR TITLE
Fix: listing responses don't include cache-control header

### DIFF
--- a/exodus_lambda/functions/origin_request.py
+++ b/exodus_lambda/functions/origin_request.py
@@ -130,6 +130,7 @@ class OriginRequest(LambdaBase):
 
         listing_response = self.handle_listing_request(uri)
         if listing_response:
+            self.set_cache_control(uri, listing_response)
             return listing_response
 
         self.logger.info(

--- a/exodus_lambda/functions/origin_response.py
+++ b/exodus_lambda/functions/origin_response.py
@@ -1,5 +1,4 @@
 import json
-import re
 from base64 import b64encode
 
 from .base import LambdaBase
@@ -31,14 +30,6 @@ class OriginResponse(LambdaBase):
                 {"key": "Digest", "value": f"id-sha-256={sum_b64}"}
             ]
 
-        max_age = self.conf["headers"]["max_age"]
-        max_age_pattern_whitelist = [
-            ".+/PULP_MANIFEST",
-            ".+/listing",
-            ".+/repodata/repomd.xml",
-            ".+/ostree/repo/refs/heads/.*/.*",
-        ]
-
         try:
             original_uri = request["headers"]["exodus-original-uri"][0][
                 "value"
@@ -52,14 +43,7 @@ class OriginResponse(LambdaBase):
             original_uri = None
 
         if original_uri:
-            for pattern in max_age_pattern_whitelist:
-                if re.match(pattern, original_uri):
-                    response["headers"]["cache-control"] = [
-                        {"key": "Cache-Control", "value": f"max-age={max_age}"}
-                    ]
-                    self.logger.info(
-                        "Cache-Control header added for '%s'", original_uri
-                    )
+            self.set_cache_control(original_uri, response)
 
         return response
 

--- a/support/reftest/data.yml
+++ b/support/reftest/data.yml
@@ -32,6 +32,7 @@ test_data:
 - path: /content/dist/rhel/server/5/5.7/listing
   sha256: b51f4ddc06fddec9e73892671f1f25300ccd4235fa798afd01caf96446dc2bf1
   content-type: text/plain
+  deploy: false
 # PULP_MANIFEST
 - path: /content/dist/rhel8/8.2/x86_64/baseos/iso/PULP_MANIFEST
   sha256: 2fb7a09fd67432ad7b7c95d24fe332827e24920347319c24bfef236cb0b72f19

--- a/support/reftest/reftest
+++ b/support/reftest/reftest
@@ -195,6 +195,10 @@ def download_to_local(url, key_path, cert_path, cacert_path):
 
 def prepare(db_client, s3_client, config, opt):
     for item in config.test_data:
+        if not item.get("deploy", True):
+            # skip items that specify deploy=false
+            continue
+
         url = config.prod_cdn_url + item["path"]
         # download test data to local with a name "NamedTemporaryFile"
         temp_file, cdn_data_checksum = download_to_local(

--- a/tests/functions/test_origin_request.py
+++ b/tests/functions/test_origin_request.py
@@ -299,7 +299,10 @@ def test_origin_request_listing_typical(mocked_cache, caplog):
         "status": "200",
         "statusDescription": "OK",
         "headers": {
-            "content-type": [{"key": "Content-Type", "value": "text/plain"}]
+            "content-type": [{"key": "Content-Type", "value": "text/plain"}],
+            "cache-control": [
+                {"key": "Cache-Control", "value": "max-age=600"}
+            ],
         },
     }
 

--- a/tests/integration/test_exodus.py
+++ b/tests/integration/test_exodus.py
@@ -47,25 +47,31 @@ def test_header_cache_control(cdn_test_url, testdata_path):
 
 def test_header_want_digest_GET(cdn_test_url):
     headers = {"want-digest": "id-sha-256"}
-    url = cdn_test_url + "/content/dist/rhel/server/5/5.7/listing"
+    url = (
+        cdn_test_url
+        + "/content/dist/rhel/server/7/7.2/x86_64/rhev-mgmt-agent/3/os/repodata/repomd.xml"
+    )
     r = requests.get(url, headers=headers)
     print(json.dumps(dict(r.headers), indent=2))
     assert r.status_code == 200
     assert (
         r.headers["digest"]
-        == "id-sha-256=tR9N3Ab93snnOJJnHx8lMAzNQjX6eYr9Acr5ZEbcK/E="
+        == "id-sha-256=hYGantfjJjDl4O5HesjPpwtIG2V5vWIuIOfuki9ThDk="
     )
 
 
 def test_header_want_digest_HEAD(cdn_test_url):
     headers = {"want-digest": "id-sha-256"}
-    url = cdn_test_url + "/content/dist/rhel/server/5/5.7/listing"
+    url = (
+        cdn_test_url
+        + "/content/dist/rhel/server/7/7.2/x86_64/rhev-mgmt-agent/3/os/repodata/repomd.xml"
+    )
     r = requests.head(url, headers=headers)
     print(json.dumps(dict(r.headers), indent=2))
     assert r.status_code == 200
     assert (
         r.headers["digest"]
-        == "id-sha-256=tR9N3Ab93snnOJJnHx8lMAzNQjX6eYr9Acr5ZEbcK/E="
+        == "id-sha-256=hYGantfjJjDl4O5HesjPpwtIG2V5vWIuIOfuki9ThDk="
     )
 
 


### PR DESCRIPTION
Listing files are no longer expected on CDN but should still return a
cache-control header.

Additionally, altered integration test data so as to not upload/publish
listing files.