### PR TITLE
Make reftest script initialize exodus-config [RHELDST-9306]

### DIFF
--- a/support/reftest/data.yml
+++ b/support/reftest/data.yml
@@ -35,7 +35,7 @@ test_data:
   deploy: false
 # PULP_MANIFEST
 - path: /content/dist/rhel8/8.2/x86_64/baseos/iso/PULP_MANIFEST
-  sha256: 2fb7a09fd67432ad7b7c95d24fe332827e24920347319c24bfef236cb0b72f19
+  sha256: 9ffeee1021dc043fec158c6feb28f7eba65db631d95e1725fd200adc3f3ed389
   content-type: text/plain
 # */ostree/repo/refs/heads/*/* unstable content skip checksum-verify
 - path: /content/dist/rhel/atomic/7/7Server/x86_64/ostree/repo/refs/heads/rhel-atomic-host/7/x86_64/standard

--- a/support/reftest/exodus-config.json
+++ b/support/reftest/exodus-config.json
@@ -1,0 +1,34 @@
+{
+    "origin_alias": [
+        {
+            "src": "/content/origin",
+            "dest": "/origin"
+        },
+        {
+            "src": "/origin/rpm",
+            "dest": "/origin/rpms"
+        }
+    ],
+    "rhui_alias": [
+        {
+            "src": "/content/aus/rhel/rhui",
+            "dest": "/content/aus/rhel"
+        },
+        {
+            "src": "/content/dist/rhel8/rhui",
+            "dest": "/content/dist/rhel8"
+        }
+    ],
+    "releasever_alias": [
+        {
+            "src": "/content/dist/rhel/server/6/6Server",
+            "dest": "/content/dist/rhel/server/6/6.10"
+        }
+    ],
+    "listing": {
+        "/content/dist/rhel/server/5/5.7": {
+            "var": "basearch",
+            "values": ["i386", "ia64", "x86_64"]
+        }
+    }
+}

--- a/support/reftest/reftest
+++ b/support/reftest/reftest
@@ -8,6 +8,7 @@ It requires a "data.yml" file specifying the reference test data.
 
 import argparse
 import hashlib
+import json
 import os
 import sys
 import tempfile
@@ -20,9 +21,10 @@ from tqdm import tqdm
 
 
 class DBHandler:
-    def __init__(self, table, session):
+    def __init__(self, table, config_table, session):
         self.dynamodb = session.client("dynamodb")
         self.table = table
+        self.config_table = config_table
 
         self.default_from_date = datetime.utcnow().isoformat(
             timespec="seconds"
@@ -51,6 +53,21 @@ class DBHandler:
 
         self.dynamodb.put_item(
             TableName=self.table,
+            Item=item,
+        )
+
+    def put_config(self, config, from_date=None):
+        if not from_date:
+            from_date = self.default_from_date
+
+        item = {
+            "from_date": {"S": from_date},
+            "config_id": {"S": "exodus-config"},
+            "config": {"S": json.dumps(config)},
+        }
+
+        self.dynamodb.put_item(
+            TableName=self.config_table,
             Item=item,
         )
 
@@ -129,7 +146,7 @@ def parse_args():
         help="""
         prepare reference test data in dynamodb and s3
         for integration test,
-         e.g. $./reftest prepare --bucket exodus-bucket --table exodus-table
+         e.g. $./reftest prepare --bucket exodus-bucket --table exodus-table --config-table exodus-config
         """,
     )
     parser_prepare.add_argument(
@@ -149,20 +166,30 @@ def parse_args():
         required=True,
         help="The AWS dynamoDB used to store test data",
     )
+    parser_prepare.add_argument(
+        "--config-table",
+        required=True,
+        help="The AWS dynamoDB used to store Exodus config",
+    )
 
     return root_parser.parse_args()
 
 
 class RefTestConfig:
-    def __init__(self, prod_cdn_url, test_data):
+    def __init__(self, prod_cdn_url, test_data, test_config):
         self.prod_cdn_url = prod_cdn_url
         self.test_data = test_data
+        self.test_config = test_config
 
 
 def load_config():
     with open("data.yml") as data_file:
-        config = yaml.load(data_file, yaml.SafeLoader)
-    return RefTestConfig(config["prod-cdn-url"], config["test_data"])
+        data = yaml.load(data_file, yaml.SafeLoader)
+
+    with open("exodus-config.json") as config_file:
+        config = json.load(config_file)
+
+    return RefTestConfig(data["prod-cdn-url"], data["test_data"], config)
 
 
 # It will return a TempFileObj and a checksum for test data verification
@@ -228,6 +255,9 @@ def prepare(db_client, s3_client, config, opt):
         # delete the NamedTemporaryFile
         temp_file.close()
 
+    # deploy Exodus config to config table
+    db_client.put_config(config.test_config)
+
     return True
 
 
@@ -242,7 +272,7 @@ def main():
         region_name=opt.default_region,
     )
 
-    db_client = DBHandler(table=opt.table, session=session)
+    db_client = DBHandler(table=opt.table, config_table=opt.config_table, session=session)
     s3_client = S3Handler(bucket=opt.bucket, session=session)
 
     res = False


### PR DESCRIPTION
I've confirmed that this works to deploy config to the provided config-table and that integration tests pass using said config.