### PR TITLE
reftest: add progress bar for uploads

### DIFF
--- a/support/reftest/reftest
+++ b/support/reftest/reftest
@@ -78,10 +78,24 @@ class S3Handler:
         self.bucket = bucket
 
     def upload_from_localfile(self, path, checksum):
-        with open(path, "rb") as data:
-            self.s3_client.upload_fileobj(
-                Fileobj=data, Bucket=self.bucket, Key=checksum
-            )
+        st = os.stat(path)
+        bar = tqdm(
+            desc="%s [upload]" % checksum,
+            total=st.st_size,
+            unit="iB",
+            unit_scale=True,
+        )
+
+        try:
+            with open(path, "rb") as data:
+                self.s3_client.upload_fileobj(
+                    Fileobj=data,
+                    Bucket=self.bucket,
+                    Key=checksum,
+                    Callback=bar.update,
+                )
+        finally:
+            bar.close()
 
 
 def parse_aws_session(parser):


### PR DESCRIPTION
This script performs both downloads and uploads for some large-ish
files. We previously had a progress bar for downloads, but not
uploads.

For me at least the uploads can be slow enough to give the impression
that the script is stuck, so let's add a progress bar for uploads too.