### PR TITLE
Return 404 responses for 'absent' items [RHELDST-9952]

### DIFF
--- a/exodus_lambda/functions/origin_request.py
+++ b/exodus_lambda/functions/origin_request.py
@@ -168,15 +168,19 @@ class OriginRequest(LambdaBase):
             self.logger.info("Item found for '%s'", uri)
 
             try:
+                # Validate If the item's "object_key" is "absent"
+                object_key = query_result["Items"][0]["object_key"]["S"]
+                if object_key == "absent":
+                    self.logger.info("Item absent for '%s'", uri)
+                    return {"status": "404", "statusDescription": "Not Found"}
+
                 # Add custom header containing the original request uri
                 request["headers"]["exodus-original-uri"] = [
                     {"key": "exodus-original-uri", "value": request["uri"]}
                 ]
 
                 # Update request uri to point to S3 object key
-                request["uri"] = (
-                    "/" + query_result["Items"][0]["object_key"]["S"]
-                )
+                request["uri"] = "/" + object_key
                 content_type = (
                     query_result["Items"][0].get("content_type", {}).get("S")
                 )

--- a/tests/functions/test_origin_request.py
+++ b/tests/functions/test_origin_request.py
@@ -352,3 +352,38 @@ def test_origin_request_listing_data_not_found(
     assert "No item found for '%s'", req_uri in caplog.text
     # It should return 404.
     assert request == {"status": "404", "statusDescription": "Not Found"}
+
+
+@mock.patch("boto3.client")
+@mock.patch("exodus_lambda.functions.origin_request.cachetools")
+@mock.patch("exodus_lambda.functions.origin_request.datetime")
+def test_origin_request_absent_items(
+    mocked_datetime,
+    mocked_cache,
+    mocked_boto3_client,
+    caplog,
+):
+    req_uri = "/content/dist/rhel/some/deletion.iso"
+    real_uri = "/content/dist/rhel/some/deletion.iso"
+    mocked_datetime.now().isoformat.return_value = MOCKED_DT
+    mocked_cache.TTLCache.return_value = {"exodus-config": mock_definitions()}
+    mocked_boto3_client().query.return_value = {
+        "Items": [
+            {
+                "web_uri": {"S": real_uri},
+                "from_date": {"S": "2020-02-17T00:00:00.000+00:00"},
+                "object_key": {"S": "absent"},
+            }
+        ]
+    }
+
+    event = {"Records": [{"cf": {"request": {"uri": req_uri, "headers": {}}}}]}
+
+    with caplog.at_level(logging.DEBUG):
+        request = OriginRequest(
+            conf_file=TEST_CONF,
+        ).handler(event, context=None)
+
+    assert "Item absent for '%s'" % real_uri in caplog.text
+
+    assert request == {"status": "404", "statusDescription": "Not Found"}


### PR DESCRIPTION
In order to support the explicit deletion/hiding of content on
exodus-cdn, it should make exodus-lambda return 404 responses for URIs
which have been marked as absent.