### PR TITLE
Use signed cookies in integration tests [RHELDST-8860]

### DIFF
--- a/tests/integration/test_exodus.py
+++ b/tests/integration/test_exodus.py
@@ -4,6 +4,10 @@ import re
 import pytest
 import requests
 
+from ..test_utils.utils import generate_test_cookies
+
+TEST_COOKIES = generate_test_cookies()
+
 
 def test_exodus_basic(cdn_test_url):
     url = (
@@ -11,7 +15,7 @@ def test_exodus_basic(cdn_test_url):
         + "/content/aus/rhel/server/6/6.5/x86_64/os/Packages/c/cpio-2.10-12.el6_5.x86_64.rpm"
     )
 
-    r = requests.get(url)
+    r = requests.get(url, cookies=TEST_COOKIES)
     print(json.dumps(dict(r.headers), indent=2))
     assert r.status_code == 200
     assert "cache-control" not in r.headers
@@ -22,7 +26,7 @@ def test_header_not_exist_file(cdn_test_url):
         cdn_test_url
         + "/content/aus/rhel/server/6/6.5/x86_64/os/Packages/c/cpio-2.10-12.el6_5.x86_64.rpm_not_exist"  # noqa: E501
     )
-    r = requests.get(url)
+    r = requests.get(url, cookies=TEST_COOKIES)
     print(json.dumps(dict(r.headers), indent=2))
     assert r.status_code == 404
     assert "cache-control" not in r.headers
@@ -40,7 +44,7 @@ testdata_cache_control_path = [
 @pytest.mark.parametrize("testdata_path", testdata_cache_control_path)
 def test_header_cache_control(cdn_test_url, testdata_path):
     url = cdn_test_url + testdata_path
-    r = requests.get(url)
+    r = requests.get(url, cookies=TEST_COOKIES)
     print(json.dumps(dict(r.headers), indent=2))
     assert r.status_code == 200
     assert re.match("^max-age=[0-9]+$", r.headers["cache-control"])
@@ -52,7 +56,7 @@ def test_header_want_digest_GET(cdn_test_url):
         cdn_test_url
         + "/content/dist/rhel/server/7/7.2/x86_64/rhev-mgmt-agent/3/os/repodata/repomd.xml"
     )
-    r = requests.get(url, headers=headers)
+    r = requests.get(url, headers=headers, cookies=TEST_COOKIES)
     print(json.dumps(dict(r.headers), indent=2))
     assert r.status_code == 200
     assert (
@@ -67,7 +71,7 @@ def test_header_want_digest_HEAD(cdn_test_url):
         cdn_test_url
         + "/content/dist/rhel/server/7/7.2/x86_64/rhev-mgmt-agent/3/os/repodata/repomd.xml"
     )
-    r = requests.head(url, headers=headers)
+    r = requests.head(url, headers=headers, cookies=TEST_COOKIES)
     print(json.dumps(dict(r.headers), indent=2))
     assert r.status_code == 200
     assert (
@@ -99,7 +103,7 @@ def assert_content_type(url, content_type):
 @pytest.mark.parametrize("testdata_path", testdata_content_type_path)
 def test_content_type_header_GET(cdn_test_url, testdata_path):
     url = cdn_test_url + testdata_path
-    r = requests.get(url)
+    r = requests.get(url, cookies=TEST_COOKIES)
     print(json.dumps(dict(r.headers), indent=2))
     assert r.status_code == 200
     assert_content_type(url, r.headers["Content-Type"])
@@ -108,7 +112,7 @@ def test_content_type_header_GET(cdn_test_url, testdata_path):
 @pytest.mark.parametrize("testdata_path", testdata_content_type_path)
 def test_content_type_header_HEAD(cdn_test_url, testdata_path):
     url = cdn_test_url + testdata_path
-    r = requests.head(url)
+    r = requests.head(url, cookies=TEST_COOKIES)
     print(json.dumps(dict(r.headers), indent=2))
     assert r.status_code == 200
     assert_content_type(url, r.headers["Content-Type"])
@@ -127,7 +131,7 @@ testdata_origin_alias_path = [
 def test_origin_path_alias(cdn_test_url, testdata_path):
     headers = {"want-digest": "id-sha-256"}
     url = cdn_test_url + testdata_path
-    r = requests.head(url, headers=headers)
+    r = requests.head(url, headers=headers, cookies=TEST_COOKIES)
     print(json.dumps(dict(r.headers), indent=2))
     assert r.status_code == 200
     assert (
@@ -146,7 +150,7 @@ testdata_rhui_alias_path_aus = [
 def test_rhui_path_alias_aus(cdn_test_url, testdata_path):
     headers = {"want-digest": "id-sha-256"}
     url = cdn_test_url + testdata_path
-    r = requests.head(url, headers=headers)
+    r = requests.head(url, headers=headers, cookies=TEST_COOKIES)
     print(json.dumps(dict(r.headers), indent=2))
     assert r.status_code == 200
     assert (
@@ -165,7 +169,7 @@ testdata_rhui_alias_path_rhel8 = [
 def test_rhui_path_alias_rhel8(cdn_test_url, testdata_path):
     headers = {"want-digest": "id-sha-256"}
     url = cdn_test_url + testdata_path
-    r = requests.head(url, headers=headers)
+    r = requests.head(url, headers=headers, cookies=TEST_COOKIES)
     print(json.dumps(dict(r.headers), indent=2))
     assert r.status_code == 200
     assert (
@@ -184,7 +188,7 @@ testdata_releasever_alias_rhel6 = [
 def test_releasever_alias_rhel6(cdn_test_url, testdata_path):
     headers = {"want-digest": "id-sha-256"}
     url = cdn_test_url + testdata_path
-    r = requests.head(url, headers=headers)
+    r = requests.head(url, headers=headers, cookies=TEST_COOKIES)
     print(json.dumps(dict(r.headers), indent=2))
     assert r.status_code == 200
     assert (
@@ -201,7 +205,7 @@ testdata_no_content_type = [
 @pytest.mark.parametrize("testdata_path", testdata_no_content_type)
 def test_no_content_type(cdn_test_url, testdata_path):
     url = cdn_test_url + testdata_path
-    r = requests.get(url)
+    r = requests.get(url, cookies=TEST_COOKIES)
     print(json.dumps(dict(r.headers), indent=2))
     assert r.status_code == 200
     assert r.headers["Content-Type"] == "application/octet-stream"
@@ -215,6 +219,6 @@ testdata_absent_item = [
 @pytest.mark.parametrize("testdata_path", testdata_absent_item)
 def test_absent_item(cdn_test_url, testdata_path):
     url = cdn_test_url + testdata_path
-    r = requests.get(url)
+    r = requests.get(url, cookies=TEST_COOKIES)
     print(json.dumps(dict(r.headers), indent=2))
     assert r.status_code == 404

--- a/tests/test_utils/utils.py
+++ b/tests/test_utils/utils.py
@@ -1,5 +1,8 @@
 import json
 import os
+from datetime import datetime, timedelta, timezone
+
+from exodus_lambda.functions.signer import Signer
 
 CONF_FILE = os.environ.get("EXODUS_LAMBDA_CONF_FILE")
 
@@ -50,3 +53,22 @@ def mock_definitions():
         exodus_config = json.load(f)
 
     return exodus_config
+
+
+def generate_test_cookies():
+    # Env var for using signed cookies
+    key = os.environ.get("EXODUS_CDN_PRIVATE_KEY")
+    key_id = os.environ.get("EXODUS_CDN_KEY_ID")
+
+    if not key or not key_id:
+        # envvar absent, requests will not be signed
+        return {}
+
+    expiration = datetime.now(timezone.utc) + timedelta(hours=1)
+    signer = Signer(key, key_id)
+    cookies = signer.cookies_for_policy(
+        append="",
+        resource="https://*",
+        date_less_than=expiration,
+    )
+    return {item.split("=")[0]: item.split("=")[1] for item in cookies}


### PR DESCRIPTION
If tests are run without the two env vars "EXODUS_CDN_PRIVATE_KEY"
and "EXODUS_CDN_PRIVATE_KEY", requests will not be signed.