### PR TITLE
Fix a template error

### DIFF
--- a/configuration/exodus-lambda-deploy.yaml
+++ b/configuration/exodus-lambda-deploy.yaml
@@ -32,8 +32,8 @@ Parameters:
 Conditions:
   EnableKeyGroup: !Not
     - !Equals
-      - !Ref keyids
-      - None
+      - !Join ["", !Ref keyids]
+      - ""
 
 Resources:
   KeyGroup:


### PR DESCRIPTION
CF stack "exodus-lambda-dev" throw a template error: every Fn::Equals
object requires a list of 2 string parameters.

(1) Cast keyids(CommaDelimitedList) to String
(2) None -> ""