### PR TITLE
Fix condition in lambda deploy template

### DIFF
--- a/configuration/exodus-lambda-deploy.yaml
+++ b/configuration/exodus-lambda-deploy.yaml
@@ -30,10 +30,8 @@ Parameters:
     Description: A list of secret key IDs for Distribution key groups
 
 Conditions:
-  EnableKeyGroup: !Not
-    - !Equals
-      - !Join ["", !Ref keyids]
-      - ""
+  EnableKeyGroup:
+    !Not [!Equals [!Join ["", !Ref keyids], None]]
 
 Resources:
   KeyGroup:


### PR DESCRIPTION
Previously, the EnableKeyGroup condition in exodus-lambda-deploy.yaml
checked that a joined list of keyids was an empty string. However, the
default value of keyids is the string "None", so the joined keyids
string will never be "".

The failure of this condition meant that an attempt was made to create
a KeyGroup resource even when no valid IDs existed.

This commit corrects the condition to look for the string "None".