### PR TITLE
Fix distribution deployment

### DIFF
--- a/configuration/exodus-lambda-deploy.yaml
+++ b/configuration/exodus-lambda-deploy.yaml
@@ -86,7 +86,7 @@ Resources:
               LambdaFunctionARN: !Ref OriginResponseFunc.Version
           TargetOriginId: !Sub S3-${project}-cdn-${env}
           TrustedKeyGroups:
-            !If
+            - !If
               - EnableKeyGroup
               - !Ref KeyGroup
               - !Ref AWS::NoValue


### PR DESCRIPTION
Cache behavior of distributions require a list of trusted key groups,
but was being given a string value in our template,
exodus-lambda-deploy.yaml. This commit corrects the mistake.