### PR TITLE
Allow AWS endpoint URL to be customized

### DIFF
--- a/exodus_lambda/functions/origin_request.py
+++ b/exodus_lambda/functions/origin_request.py
@@ -12,6 +12,12 @@ from .signer import Signer
 
 CONF_FILE = os.environ.get("EXODUS_LAMBDA_CONF_FILE") or "lambda_config.json"
 
+# Endpoint for AWS services.
+# Normally, should be None.
+# You might want to try e.g. "https://localhost:3377" if you want to test
+# this code against localstack.
+ENDPOINT_URL = os.environ.get("EXODUS_AWS_ENDPOINT_URL") or None
+
 
 class OriginRequest(LambdaBase):
     def __init__(self, conf_file=CONF_FILE):
@@ -29,7 +35,11 @@ class OriginRequest(LambdaBase):
     @property
     def db_client(self):
         if not self._db_client:
-            self._db_client = boto3.client("dynamodb", region_name=self.region)
+            self._db_client = boto3.client(
+                "dynamodb",
+                region_name=self.region,
+                endpoint_url=ENDPOINT_URL,
+            )
 
         return self._db_client
 
@@ -37,7 +47,9 @@ class OriginRequest(LambdaBase):
     def sm_client(self):
         if not self._sm_client:
             self._sm_client = boto3.client(
-                "secretsmanager", region_name=self.region
+                "secretsmanager",
+                region_name=self.region,
+                endpoint_url=ENDPOINT_URL,
             )
 
         return self._sm_client


### PR DESCRIPTION
If EXODUS_AWS_ENDPOINT_URL env var is set, we'll use that as the AWS
endpoint URL when constructing boto clients.

This will never be used in production. The motivation is only to enable
testing against an instance of localstack.