### PR TITLE
Allow AWS endpoint URL to be customized

### DIFF
--- a/exodus_lambda/functions/origin_request.py
+++ b/exodus_lambda/functions/origin_request.py
@@ -12,6 +12,12 @@ from .signer import Signer
 
 CONF_FILE = os.environ.get("EXODUS_LAMBDA_CONF_FILE") or "lambda_config.json"
 
+# Endpoint for AWS services.
+# Normally, should be None.
+# You might want to try e.g. "https://localhost:3377" if you want to test
+# this code against localstack.
+ENDPOINT_URL = os.environ.get("EXODUS_AWS_ENDPOINT_URL") or None
+
 
 class OriginRequest(LambdaBase):
     def __init__(self, conf_file=CONF_FILE):
@@ -29,7 +35,11 @@ class OriginRequest(LambdaBase):
     @property
     def db_client(self):
         if not self._db_client:
-            self._db_client = boto3.client("dynamodb", region_name=self.region)
+            self._db_client = boto3.client(
+                "dynamodb",
+                region_name=self.region,
+                endpoint_url=ENDPOINT_URL,
+            )
 
         return self._db_client
 
@@ -37,7 +47,9 @@ class OriginRequest(LambdaBase):
     def sm_client(self):
         if not self._sm_client:
             self._sm_client = boto3.client(
-                "secretsmanager", region_name=self.region
+                "secretsmanager",
+                region_name=self.region,
+                endpoint_url=ENDPOINT_URL,
             )
 
         return self._sm_client

--- a/support/reftest/reftest
+++ b/support/reftest/reftest
@@ -21,10 +21,12 @@ from tqdm import tqdm
 
 DATA_DIR = os.path.dirname(__file__)
 
+ENDPOINT_URL = os.environ.get("EXODUS_AWS_ENDPOINT_URL") or None
+
 
 class DBHandler:
     def __init__(self, table, config_table, session):
-        self.dynamodb = session.client("dynamodb")
+        self.dynamodb = session.client("dynamodb", endpoint_url=ENDPOINT_URL)
         self.table = table
         self.config_table = config_table
 
@@ -93,7 +95,7 @@ class DBHandler:
 
 class S3Handler:
     def __init__(self, bucket, session):
-        self.s3_client = session.client("s3")
+        self.s3_client = session.client("s3", endpoint_url=ENDPOINT_URL)
         self.bucket = bucket
 
     def upload_from_localfile(self, path, checksum):


### PR DESCRIPTION
If EXODUS_AWS_ENDPOINT_URL env var is set, we'll use that as the AWS
endpoint URL when constructing boto clients.

This will never be used in production. The motivation is only to enable
testing against an instance of localstack.

The same applies to the reftest support script, as that also works fine
against localstack if the endpoint URL is set. Though reftest has
command-line arguments, the same env var is used there for consistency.