### PR TITLE
Add "X-Exodus-Query" header

### DIFF
--- a/configuration/exodus-lambda-deploy.yaml
+++ b/configuration/exodus-lambda-deploy.yaml
@@ -63,6 +63,7 @@ Resources:
             HeaderBehavior: whitelist
             Headers:
               - Want-Digest
+              - X-Exodus-Query
           QueryStringsConfig:
             QueryStringBehavior: none
 

--- a/configuration/lambda_config.template
+++ b/configuration/lambda_config.template
@@ -18,6 +18,7 @@
   },
   "secret_arn": "$EXODUS_SECRET_ARN",
   "key_id": "$EXODUS_KEY_ID",
+  "lambda_version": "$EXODUS_LAMBDA_VERSION",
   "logging": {
     "version": 1,
     "incremental": "True",

--- a/exodus_lambda/functions/base.py
+++ b/exodus_lambda/functions/base.py
@@ -49,6 +49,10 @@ class LambdaBase(object):
     def max_age(self):
         return self.conf["headers"]["max_age"]
 
+    @property
+    def lambda_version(self):
+        return self.conf["lambda_version"]
+
     def set_cache_control(self, uri, response):
         max_age_pattern_whitelist = [
             ".+/PULP_MANIFEST",

--- a/exodus_lambda/functions/origin_response.py
+++ b/exodus_lambda/functions/origin_response.py
@@ -33,6 +33,11 @@ class OriginResponse(LambdaBase):
                 {"key": "Digest", "value": f"id-sha-256={sum_b64}"}
             ]
 
+        if "headers" in request and "x-exodus-query" in request["headers"]:
+            response["headers"]["x-exodus-version"] = [
+                {"key": "X-Exodus-Version", "value": self.lambda_version}
+            ]
+
         try:
             original_uri = request["headers"]["exodus-original-uri"][0][
                 "value"

--- a/scripts/mk-config
+++ b/scripts/mk-config
@@ -14,4 +14,7 @@ export EXODUS_CONFIG_TABLE=${EXODUS_CONFIG_TABLE:-$PROJECT-config-$ENV_TYPE}
 export EXODUS_SECRET_ARN=${EXODUS_SECRET_ARN}
 export EXODUS_KEY_ID=${EXODUS_KEY_ID}
 
+REVISION="${CODEBUILD_RESOLVED_SOURCE_VERSION:-$(git rev-parse HEAD)}"
+export EXODUS_LAMBDA_VERSION="${EXODUS_LAMBDA_VERSION:-$(date -u --iso=s) ${REVISION}}"
+
 envsubst < ./configuration/lambda_config.template

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,6 +63,7 @@ def mock_conf_file():
     test_env["EXODUS_KEY_ID"] = "K1MOU91G3N7WPY"
     test_env["ORIGIN_RESPONSE_LOGGER_LEVEL"] = "DEBUG"
     test_env["ORIGIN_REQUEST_LOGGER_LEVEL"] = "DEBUG"
+    test_env["EXODUS_LAMBDA_VERSION"] = "fake version"
 
     cmd = "envsubst < ./configuration/lambda_config.template > {temp_path}"
     cmd = cmd.format(temp_path=temp_file.name)

--- a/tests/functions/test_origin_response.py
+++ b/tests/functions/test_origin_response.py
@@ -11,14 +11,16 @@ MAX_AGE = TEST_CONF["headers"]["max_age"]
 
 
 @pytest.mark.parametrize(
-    "original_uri, want_digest",
+    "original_uri, want_digest, x_exodus_query",
     [
-        ("/some/repo/listing", True),
-        ("/some/repo/repodata/repomd.xml", True),
-        ("/some/repo/ostree/repo/refs/heads/ok/test", False),
+        ("/some/repo/listing", True, False),
+        ("/some/repo/repodata/repomd.xml", True, False),
+        ("/some/repo/ostree/repo/refs/heads/ok/test", False, True),
     ],
 )
-def test_origin_response_valid_headers(original_uri, want_digest):
+def test_origin_response_valid_headers(
+    original_uri, want_digest, x_exodus_query
+):
     event = {
         "Records": [
             {
@@ -56,6 +58,17 @@ def test_origin_response_valid_headers(original_uri, want_digest):
                 "key": "Digest",
                 "value": "id-sha-256=vn8wB98+UftI//V9qcAcUua45g7OrKt6rw"
                 "4FtXV4STo=",
+            }
+        ]
+
+    if x_exodus_query:
+        event["Records"][0]["cf"]["request"]["headers"]["x-exodus-query"] = [
+            {"key": "X-Exodus-Query", "value": "true"}
+        ]
+        expected_headers["x-exodus-version"] = [
+            {
+                "key": "X-Exodus-Version",
+                "value": "fake version",
             }
         ]
 


### PR DESCRIPTION
Because of the traffic shift and traffic will be routed to different
lambda versions (in different regions), integration tests may run again
an old version lambda.

The "X-Exodus-Query" header is primarily used in a request, to provide
the version of exodus-lambda, "X-Exodus-Version" in response.

For traffic shift:
https://aws.amazon.com/blogs/compute/implementing-safe-aws-lambda-deployments-with-aws-codedeploy/