### PR TITLE
refactor: ensure X-Exodus-Version works for synthesized responses too

### DIFF
--- a/exodus_lambda/functions/base.py
+++ b/exodus_lambda/functions/base.py
@@ -53,6 +53,12 @@ class LambdaBase(object):
     def lambda_version(self):
         return self.conf["lambda_version"]
 
+    def add_lambda_version(self, response):
+        """Ensure a response includes the X-Exodus-Version header with an appropriate value."""
+        response.setdefault("headers", {})["x-exodus-version"] = [
+            {"key": "X-Exodus-Version", "value": self.lambda_version}
+        ]
+
     def set_cache_control(self, uri, response):
         max_age_pattern_whitelist = [
             ".+/PULP_MANIFEST",

--- a/exodus_lambda/functions/origin_request.py
+++ b/exodus_lambda/functions/origin_request.py
@@ -1,3 +1,4 @@
+import functools
 import json
 import os
 import time
@@ -31,6 +32,8 @@ class OriginRequest(LambdaBase):
             ).total_seconds(),
             timer=time.monotonic,
         )
+
+        self.handler = self.maybe_add_version(self.handler)
 
     @property
     def db_client(self):
@@ -226,6 +229,27 @@ class OriginRequest(LambdaBase):
                 self.logger.info("No listing data defined")
 
         return {}
+
+    def maybe_add_version(self, handler):
+        """Decorator wrapping every request to add x-exodus-version on responses,
+        where appropriate.
+        """
+
+        @functools.wraps(handler)
+        def new_handler(event, context):
+            request = event["Records"][0]["cf"]["request"]
+            response = handler(event, context)
+
+            # If the request asked for the version, and the response is terminal
+            # (meaning we won't reach origin-response), add the version here
+            if "status" in response and "x-exodus-query" in (
+                request.get("headers") or {}
+            ):
+                self.add_lambda_version(response)
+
+            return response
+
+        return new_handler
 
     def handler(self, event, context):
         # pylint: disable=unused-argument

--- a/exodus_lambda/functions/origin_response.py
+++ b/exodus_lambda/functions/origin_response.py
@@ -34,9 +34,7 @@ class OriginResponse(LambdaBase):
             ]
 
         if "headers" in request and "x-exodus-query" in request["headers"]:
-            response["headers"]["x-exodus-version"] = [
-                {"key": "X-Exodus-Version", "value": self.lambda_version}
-            ]
+            self.add_lambda_version(response)
 
         try:
             original_uri = request["headers"]["exodus-original-uri"][0][


### PR DESCRIPTION
If the logic for setting X-Exodus-Version lives only in origin-response,
it can't work for responses generated directly without going to origin,
e.g. /listing files, /_/cookie, 404 errors and maybe some other things
in the future.

Implement it also in origin-request, in a way which ensures it can't be
forgotten as handler is extended.