### PR TITLE
renovate: set the allowed managers (disabling others)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,6 @@
 {
   "enabled": true,
+  "enabledManagers": ["dockerfile", "github-actions"],
   "dockerfile": {
     "fileMatch": [".*Containerfile$"]
   },


### PR DESCRIPTION
We don't use renovate for updating python dependencies as we are using
pip-compile for that. Explicitly set the managers we want to use so that
others won't create PRs.