### PR TITLE
Replace coveralls in CI with coverage CLI option [RHELDST-11054]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,6 @@ jobs:
         pip install tox
 
     - name: Run auto-tests
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
       run: tox -e cov-ci
 
     - name: Run static analysis

--- a/tox.ini
+++ b/tox.ini
@@ -21,11 +21,9 @@ commands=
 	pytest --cov-report=html --cov=exodus_lambda {posargs}
 
 [testenv:cov-ci]
-passenv=GITHUB_*
 usedevelop=true
 commands=
-	pytest --cov=exodus_lambda {posargs}
-	coveralls --service=github
+	pytest --cov-fail-under=100 --cov=exodus_lambda {posargs}
 
 [testenv:docs]
 use_develop=true


### PR DESCRIPTION
This commit removes coveralls integration with CI workflow, replacing it
with the --cov-fail-under option available through pytest-cov.