### PR TITLE
refactor: ensure X-Exodus-Version works for synthesized responses too

### DIFF
--- a/exodus_lambda/functions/base.py
+++ b/exodus_lambda/functions/base.py
@@ -53,6 +53,11 @@ class LambdaBase(object):
     def lambda_version(self):
         return self.conf["lambda_version"]
 
+    def set_lambda_version(self, response):
+        response.setdefault("headers", {})["x-exodus-version"] = [
+            {"key": "X-Exodus-Version", "value": self.lambda_version}
+        ]
+
     def set_cache_control(self, uri, response):
         max_age_pattern_whitelist = [
             ".+/PULP_MANIFEST",

--- a/exodus_lambda/functions/origin_response.py
+++ b/exodus_lambda/functions/origin_response.py
@@ -34,9 +34,7 @@ class OriginResponse(LambdaBase):
             ]
 
         if "headers" in request and "x-exodus-query" in request["headers"]:
-            response["headers"]["x-exodus-version"] = [
-                {"key": "X-Exodus-Version", "value": self.lambda_version}
-            ]
+            self.set_lambda_version(response)
 
         try:
             original_uri = request["headers"]["exodus-original-uri"][0][


### PR DESCRIPTION
If the logic for setting X-Exodus-Version lives only in origin-response,
it can't work for responses generated directly without going to origin,
e.g. /listing files, /_/cookie, 404 errors and maybe some other things
in the future.

Implement it also in origin-request, in a way which ensures it can't be
forgotten as handler is extended.