### PR TITLE
Revise the env var scheme for log levels [RHELDST-11210]

### DIFF
--- a/docs/deploy.rst
+++ b/docs/deploy.rst
@@ -80,8 +80,16 @@ All variables not listed as "required" have reasonable defaults.
     ``EXODUS_LOG_FORMAT``
         Format string for Python loggers.
 
-    ``EXODUS_<loggername>_LOG_LEVEL``
-        Set the log level of a specified logger (e.g. to "INFO", "DEBUG", etc.)
+    ``EXODUS_LOGGER_*``
+        Should contain a value of the form ``<loggername> <level>``,
+        such as ``origin-request DEBUG``.
+
+        Sets the level of the specified logger.
+
+        The environment variable's wildcard suffix allows for any number
+        of loggers to be configured. The specific value used as a suffix
+        has no effect.
+
 
 
 .. _AWS CloudFormation: https://aws.amazon.com/cloudformation/

--- a/exodus_lambda/functions/config.py
+++ b/exodus_lambda/functions/config.py
@@ -196,17 +196,23 @@ class EnvironmentLambdaConfig(LambdaConfig):
 
         # We support setting levels on arbitrary loggers by setting env vars of the form:
         #
-        #   EXODUS_<loggername>_LOG_LEVEL
+        #   EXODUS_LOGGER_*=loggername loglevel
         #
         # Gather all such vars of that form.
-        # Note: we only support lowercase logger names.
         for varname, value in environ.items():
             varname = varname.lower()
-            if varname.endswith("_log_level") and varname.startswith(
-                "exodus_"
-            ):
-                loggername = varname[len("exodus_") : -len("_log_level")]
-                loggers[loggername] = {"level": value.upper()}
+            if varname.startswith("exodus_logger_"):
+                split = value.split(" ")
+                if len(split) < 2:
+                    LOG.warning(
+                        "Ignoring invalid logger env var: %s = %s",
+                        varname,
+                        value,
+                    )
+                else:
+                    level = split[-1]
+                    loggername = " ".join(split[0:-1])
+                    loggers[loggername] = {"level": level.upper()}
 
         return {
             "version": 1,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -104,9 +104,9 @@ def configured_env(monkeypatch):
     monkeypatch.setenv("EXODUS_CONFIG_TABLE", "test-config-table")
 
     monkeypatch.setenv("EXODUS_LOG_FORMAT", "[%(levelname)s] - %(message)s")
-    monkeypatch.setenv("EXODUS_ORIGIN-RESPONSE_LOG_LEVEL", "DEBUG")
-    monkeypatch.setenv("EXODUS_ORIGIN-REQUEST_LOG_LEVEL", "DEBUG")
-    monkeypatch.setenv("EXODUS_DEFAULT_LOG_LEVEL", "DEBUG")
+    monkeypatch.setenv("EXODUS_LOGGER_RESPONSE", "origin-response DEBUG")
+    monkeypatch.setenv("EXODUS_LOGGER_REQUEST", "origin-request DEBUG")
+    monkeypatch.setenv("EXODUS_LOGGER_DEFAULT", "default DEBUG")
 
 
 def mock_conf_file():

--- a/tests/functions/test_config.py
+++ b/tests/functions/test_config.py
@@ -9,3 +9,27 @@ from exodus_lambda.functions.config import EnvironmentLambdaConfig
 def test_default_region():
     cfg = EnvironmentLambdaConfig()
     assert cfg.item_table_regions == ["us-east-1"]
+
+
+def test_logger_levels(monkeypatch, caplog):
+    """EXODUS_LOGGER_* environment variables are parsed to set log levels."""
+
+    monkeypatch.setenv("EXODUS_LOGGER_WHATEVER", "foo bar INFO")
+    monkeypatch.setenv("EXODUS_LOGGER_OTHER", "Foo.Bar.Baz WARNING")
+    monkeypatch.setenv("EXODUS_LOGGER_INVALID", "something-bad")
+
+    cfg = EnvironmentLambdaConfig()
+    logdict = cfg.logging_config
+    assert logdict["loggers"] == {
+        # All the valid vars should have made it into the log config dict.
+        "Foo.Bar.Baz": {"level": "WARNING"},
+        "foo bar": {"level": "INFO"},
+        # There is also this default which is always included.
+        "default": {"level": "WARNING"},
+    }
+
+    # The bad env var should have caused a log.
+    assert (
+        "Ignoring invalid logger env var: exodus_logger_invalid = something-bad"
+        in caplog.text
+    )


### PR DESCRIPTION
During testing I learned that the previous scheme for allowing log
levels to be set by env vars would not work in practice, due the
following restriction when setting Lambda environment variables:

```
  Member must satisfy regular expression pattern: [a-zA-Z]([a-zA-Z0-9_])+]
```

The restriction meant that loggers with a name containing characters like '-'
or '.' could not be configured.

Revise the scheme so that the logger name does not need to appear in the
environment variable name.