### PR TITLE
fakefront: respect caller's environment variables

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -61,18 +61,18 @@ commands=
 #
 # You will have to tweak the environment variables if you use a different
 # environment, or different bucket & table names.
-passenv = EXODUS_*
+passenv = EXODUS_* ORIGIN_*
 usedevelop = true
 deps=
     gunicorn
 setenv =
-    EXODUS_AWS_ENDPOINT_URL=https://localhost:3377
-    EXODUS_TABLE=my-table
-    EXODUS_CONFIG_TABLE=my-config
-    ORIGIN_REQUEST_LOGGER_LEVEL=DEBUG
-    ORIGIN_RESPONSE_LOGGER_LEVEL=DEBUG
-    EXODUS_LOG_FORMAT=%(asctime)s - %(levelname)s - %(message)s
-    EXODUS_KEY_ID=FAKEFRONT
+    EXODUS_AWS_ENDPOINT_URL={env:EXODUS_AWS_ENDPOINT_URL:https://localhost:3377}
+    EXODUS_TABLE={env:EXODUS_TABLE:my-table}
+    EXODUS_CONFIG_TABLE={env:EXODUS_CONFIG_TABLE:my-config}
+    ORIGIN_REQUEST_LOGGER_LEVEL={env:ORIGIN_REQUEST_LOGGER_LEVEL:DEBUG}
+    ORIGIN_RESPONSE_LOGGER_LEVEL={env:ORIGIN_RESPONSE_LOGGER_LEVEL:DEBUG}
+    EXODUS_LOG_FORMAT={env:EXODUS_LOG_FORMAT:%(asctime)s - %(levelname)s - %(message)s}
+    EXODUS_KEY_ID={env:EXODUS_KEY_ID:FAKEFRONT}
 commands =
     gunicorn support.fakefront -b 127.0.0.1:8049 --reload {posargs}
 
@@ -85,14 +85,15 @@ commands =
 skip_install=true
 whitelist_externals=
     podman
+passenv = EXODUS_* ORIGIN_*
 setenv =
-    EXODUS_AWS_ENDPOINT_URL=https://localhost:3377
-    EXODUS_TABLE=my-table
-    EXODUS_CONFIG_TABLE=my-config
-    ORIGIN_REQUEST_LOGGER_LEVEL=DEBUG
-    ORIGIN_RESPONSE_LOGGER_LEVEL=DEBUG
-    EXODUS_LOG_FORMAT=%(asctime)s - %(levelname)s - %(message)s
-    EXODUS_KEY_ID=FAKEFRONT
+    EXODUS_AWS_ENDPOINT_URL={env:EXODUS_AWS_ENDPOINT_URL:https://localhost:3377}
+    EXODUS_TABLE={env:EXODUS_TABLE:my-table}
+    EXODUS_CONFIG_TABLE={env:EXODUS_CONFIG_TABLE:my-config}
+    ORIGIN_REQUEST_LOGGER_LEVEL={env:ORIGIN_REQUEST_LOGGER_LEVEL:DEBUG}
+    ORIGIN_RESPONSE_LOGGER_LEVEL={env:ORIGIN_RESPONSE_LOGGER_LEVEL:DEBUG}
+    EXODUS_LOG_FORMAT={env:EXODUS_LOG_FORMAT:%(asctime)s - %(levelname)s - %(message)s}
+    EXODUS_KEY_ID={env:EXODUS_KEY_ID:FAKEFRONT}
     REQUESTS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt
 commands =
     podman build . -t fakefront -f support/fakefront/Containerfile


### PR DESCRIPTION
By using the {env:KEY:DEFAULTVALUE} syntax in tox.ini we can respect any
environment variables set by the caller, rather than always using
hardcoded defaults. This improves the integration with exodus-gw's dev
env, where it is theoretically possible to use non-default values for
some of the config elements (e.g. to avoid port conflicts).