### PR TITLE
reftest: fix outdated checksum for one PULP_MANIFEST

### DIFF
--- a/support/reftest/data.yml
+++ b/support/reftest/data.yml
@@ -35,7 +35,7 @@ test_data:
   deploy: false
 # PULP_MANIFEST
 - path: /content/dist/rhel8/8.2/x86_64/baseos/iso/PULP_MANIFEST
-  sha256: 9ffeee1021dc043fec158c6feb28f7eba65db631d95e1725fd200adc3f3ed389
+  sha256: a530a9d758d5f6912901e2f3b9a83fe7b20cfe2e50535466ee7a3381e6805dc3
   content-type: text/plain
 # */ostree/repo/refs/heads/*/* unstable content skip checksum-verify
 - path: /content/dist/rhel/atomic/7/7Server/x86_64/ostree/repo/refs/heads/rhel-atomic-host/7/x86_64/standard


### PR DESCRIPTION
These files for historical RHEL versions shouldn't generally change, but
in this case I believe there was a request done to remove some files
from the repo, changing the manifest.