### PR TITLE
reftest: add alias paths into testdata

### DIFF
--- a/support/reftest/data.yml
+++ b/support/reftest/data.yml
@@ -14,20 +14,54 @@ test_data:
 - path: /content/dist/rhel/server/7/7.2/x86_64/rhev-mgmt-agent/3/os/repodata/repomd.xml
   sha256: 85819a9ed7e32630e5e0ee477ac8cfa70b481b6579bd622e20e7ee922f538439
   content-type: application/xml
-# rpm
-- path: /content/aus/rhel/server/6/6.5/x86_64/os/Packages/c/cpio-2.10-12.el6_5.x86_64.rpm
-  sha256: 06316538b90d3aab20f4787132307f6d330da9a48bab11a13e0a616fcf622ce5
-  content-type: application/x-rpm
-- path: /content/dist/rhel/server/6/6.10/x86_64/os/Packages/c/cpio-2.10-12.el6_5.x86_64.rpm
-  sha256: 06316538b90d3aab20f4787132307f6d330da9a48bab11a13e0a616fcf622ce5
-  content-type: application/x-rpm
-- path: /content/dist/rhel8/8.1/x86_64/baseos/os/Packages/i/iptables-1.8.2-16.el8.x86_64.rpm
-  sha256: 580d8c304c0fce98a47cf0283849e5e9f7e8f5c7bda766921249765046947e40
-  content-type: application/x-rpm
-# rpm for orgin path alias test
+
+# path alias tests.
+# Each of the below sets of content should be accessible under multiple paths due to
+# alias mechanisms, however only one copy of the file needs to be deployed.
+# origin alias:
 - path: /origin/rpms/bash/4.4.19/8.el8_0/fd431d51/bash-4.4.19-8.el8_0.x86_64.rpm
   sha256: 4164ff2c0116d666578ba5e456ab03b88788dfb42fb93fc91b2c1da709d86686
   content-type: application/x-rpm
+- path: /origin/rpm/bash/4.4.19/8.el8_0/fd431d51/bash-4.4.19-8.el8_0.x86_64.rpm
+  sha256: 4164ff2c0116d666578ba5e456ab03b88788dfb42fb93fc91b2c1da709d86686
+  content-type: application/x-rpm
+  deploy: false
+- path: /content/origin/rpm/bash/4.4.19/8.el8_0/fd431d51/bash-4.4.19-8.el8_0.x86_64.rpm
+  sha256: 4164ff2c0116d666578ba5e456ab03b88788dfb42fb93fc91b2c1da709d86686
+  content-type: application/x-rpm
+  deploy: false
+- path: /content/origin/rpms/bash/4.4.19/8.el8_0/fd431d51/bash-4.4.19-8.el8_0.x86_64.rpm
+  sha256: 4164ff2c0116d666578ba5e456ab03b88788dfb42fb93fc91b2c1da709d86686
+  content-type: application/x-rpm
+  deploy: false
+
+# rhui alias (pre-rhel8)
+- path: /content/aus/rhel/server/6/6.5/x86_64/os/Packages/c/cpio-2.10-12.el6_5.x86_64.rpm
+  sha256: 06316538b90d3aab20f4787132307f6d330da9a48bab11a13e0a616fcf622ce5
+  content-type: application/x-rpm
+- path: /content/aus/rhel/rhui/server/6/6.5/x86_64/os/Packages/c/cpio-2.10-12.el6_5.x86_64.rpm
+  sha256: 06316538b90d3aab20f4787132307f6d330da9a48bab11a13e0a616fcf622ce5
+  content-type: application/x-rpm
+  deploy: false
+
+# rhui alias (post-rhel8)
+- path: /content/dist/rhel8/8.1/x86_64/baseos/os/Packages/i/iptables-1.8.2-16.el8.x86_64.rpm
+  sha256: 580d8c304c0fce98a47cf0283849e5e9f7e8f5c7bda766921249765046947e40
+  content-type: application/x-rpm
+- path: /content/dist/rhel8/rhui/8.1/x86_64/baseos/os/Packages/i/iptables-1.8.2-16.el8.x86_64.rpm
+  sha256: 580d8c304c0fce98a47cf0283849e5e9f7e8f5c7bda766921249765046947e40
+  content-type: application/x-rpm
+  deploy: false
+
+# releasever alias
+- path: /content/dist/rhel/server/6/6.10/x86_64/os/Packages/c/cpio-2.10-12.el6_5.x86_64.rpm
+  sha256: 06316538b90d3aab20f4787132307f6d330da9a48bab11a13e0a616fcf622ce5
+  content-type: application/x-rpm
+- path: /content/dist/rhel/server/6/6Server/x86_64/os/Packages/c/cpio-2.10-12.el6_5.x86_64.rpm
+  sha256: 06316538b90d3aab20f4787132307f6d330da9a48bab11a13e0a616fcf622ce5
+  content-type: application/x-rpm
+  deploy: false
+
 # listing
 - path: /content/dist/rhel/server/5/5.7/listing
   sha256: b51f4ddc06fddec9e73892671f1f25300ccd4235fa798afd01caf96446dc2bf1


### PR DESCRIPTION
Currently, in integration tests, there are some tests covering
rhui/origin/releasever aliases. Those tests were written specifically to
test the aliasing mechanism by using hardcoded paths.

I don't think this should be required though as we can achieve the same
by simply adding paths on both sides of the alias directly in the
reftest data. This will test the aliasing mechanism by querying the
file from both paths, with no special testcase required.
The only trick is making sure that 'deploy' is set to false on all but
one copy of each file.