### PR TITLE
Add default request definitions [RHELDST-11260]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
 -   repo: https://github.com/ambv/black
-    rev: 20.8b1
+    rev: 22.6.0
     hooks:
     - id: black
       language_version: python3.9
 -   repo: https://github.com/pycqa/isort/
-    rev: 5.6.4
+    rev: 5.10.1
     hooks:
     - id: isort
       language_version: python3.9

--- a/exodus_lambda/functions/origin_request.py
+++ b/exodus_lambda/functions/origin_request.py
@@ -81,7 +81,16 @@ class OriginRequest(LambdaBase):
             if query_result["Items"]:
                 item = query_result["Items"][0]
                 out = json.loads(item["config"]["S"])
-                self._cache["exodus-config"] = out
+            else:
+                # Provide dict with expected keys when no config is found.
+                out = {
+                    "origin_alias": [],
+                    "rhui_alias": [],
+                    "releasever_alias": [],
+                    "listing": {},
+                }
+
+            self._cache["exodus-config"] = out
 
         return out
 

--- a/tests/functions/test_origin_request.py
+++ b/tests/functions/test_origin_request.py
@@ -194,7 +194,20 @@ def test_origin_request_definitions(mocked_boto3_client):
         ]
     }
 
-    assert mocked_defs == OriginRequest(conf_file=TEST_CONF).definitions
+    assert OriginRequest(conf_file=TEST_CONF).definitions == mocked_defs
+
+
+@mock.patch("boto3.client")
+def test_origin_request_definitions_not_found(mocked_boto3_client):
+    expected_defs = {
+        "origin_alias": [],
+        "rhui_alias": [],
+        "releasever_alias": [],
+        "listing": {},
+    }
+    mocked_boto3_client().query.return_value = {"Items": []}
+
+    assert OriginRequest(conf_file=TEST_CONF).definitions == expected_defs
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Previously, request definitions remained a NoneType object when queries
of config_table yielded no items, causing the origin request function to
crash when attempting to access definitions. This commit implements a
default dictionary structure to fall back on when this config is absent,
allowing the function to proceed.

The default dictionary provided contains nothing but the expected keys,
so alias mapping and listing look-ups will still not work until proper
config is provisioned to the config_table and the origin request cache
is reset.