### PR TITLE
Fix compatibility with tox 4

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ deps=
 	-r requirements.txt
 	-r test-requirements.txt
 commands=pytest {posargs}
-whitelist_externals=sh
+allowlist_externals=sh
 
 [testenv:static]
 commands=
@@ -46,7 +46,7 @@ commands=
 # Create a lambda deployment package.
 [testenv:package]
 skip_install=true
-whitelist_externals=
+allowlist_externals=
     sh
     rm
 commands=
@@ -71,7 +71,9 @@ commands=
 #
 # You will have to tweak the environment variables if you use a different
 # environment, or different bucket & table names.
-passenv = EXODUS_* ORIGIN_*
+passenv =
+    EXODUS_*
+    ORIGIN_*
 usedevelop = true
 deps=
     gunicorn
@@ -93,9 +95,11 @@ commands =
 # Otherwise there is generally no advantage in using this over
 # the 'fakefront' testenv.
 skip_install=true
-whitelist_externals=
+allowlist_externals=
     podman
-passenv = EXODUS_* ORIGIN_*
+passenv =
+    EXODUS_*
+    ORIGIN_*
 setenv =
     EXODUS_AWS_ENDPOINT_URL={env:EXODUS_AWS_ENDPOINT_URL:https://localhost:3377}
     EXODUS_TABLE={env:EXODUS_TABLE:my-table}


### PR DESCRIPTION
The term 'whitelist' must be replaced with 'allowlist' for compatibility with tox >= 4.0.0.