### PR TITLE
Add a support script to generate signed URLs/cookies from command-line

### DIFF
--- a/exodus_lambda/functions/signer.py
+++ b/exodus_lambda/functions/signer.py
@@ -1,9 +1,12 @@
 import base64
+import logging
 
 from botocore.signers import CloudFrontSigner
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding
+
+LOG = logging.getLogger(__name__)
 
 
 def cf_b64(data: bytes):
@@ -31,7 +34,11 @@ class Signer:
         )
 
     def cookies_for_policy(self, append, **kwargs):
-        policy = self.cf_signer.build_policy(**kwargs).encode("utf-8")
+        policy = self.cf_signer.build_policy(**kwargs)
+
+        LOG.debug("Signing policy: %s", policy)
+
+        policy = policy.encode("utf-8")
         signature = self.cf_signer.rsa_signer(policy)
 
         policy_b64 = cf_b64(policy).decode("utf-8")

--- a/support/signer
+++ b/support/signer
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+#
+# Helper script for manual generation of signed URLs or cookies
+# while testing.
+#
+# Requires exodus-lambda to be installed in the current python environment,
+# as it reuses exodus-lambda code.
+#
+# Example usage to generate a one-year cookie for all content on a given
+# cloudfront distribution:
+#
+#   support/signer \
+#     --key ~/src/exodus-cdn-playbooks/prod-live.pem \
+#     --key-id XXXYYYNA9A2VVX \
+#     --cookie 'https://example5gix96s.cloudfront.net/*' \
+#     --expire-days 365
+#
+import argparse
+import logging
+import os
+import sys
+import traceback
+from datetime import datetime, timedelta
+from http.client import HTTPResponse
+from tempfile import TemporaryDirectory
+from urllib.request import HTTPDefaultErrorHandler, Request, build_opener
+
+LOG = logging.getLogger("signer")
+
+
+class HTTPAllow404Handler(HTTPDefaultErrorHandler):
+    """Custom error handler to avoid raising on 404 errors.
+
+    We don't want 404 errors to be fatal because we are only trying to test
+    whether requests are reaching exodus-lambda, and not whether we are
+    requesting an existing piece of content.
+    """
+
+    def http_error_404(self, req, fp, code, msg, hdrs):
+        # Just return the response object. This is enough to avoid
+        # the default error handler raising an exception.
+        return fp
+
+
+def import_signer_class():
+    """Obtain the Signer class from exodus_lambda.
+
+    This function is used to do an indirect import here because
+    exodus-lambda has an annoying requirement that the current
+    working directory must have a lambda_config.json file at
+    import time.
+
+    To make the script more convenient to use, we'll just deploy
+    an empty file prior to import.
+    """
+
+    cwd = os.getcwd()
+
+    with TemporaryDirectory(suffix="exodus-lambda-signer") as tempdir:
+        os.chdir(tempdir)
+        open("lambda_config.json", "w").write("{}")
+        from exodus_lambda.functions.signer import Signer
+
+        os.chdir(cwd)
+
+    return Signer
+
+
+def test_request(url: str, cookies: list[str]):
+    """Verify that request to 'url' using 'cookies' successfully reaches an
+    instance of exodus-lambda.
+
+    If it does not, the script exits with a non-zero exit code.
+    """
+
+    headers = {"X-Exodus-Query": "1"}
+    if cookies:
+        headers["Cookie"] = "; ".join(cookies)
+
+    try:
+        LOG.debug(
+            "Testing request to %s with cookies %s",
+            url,
+            cookies if cookies else "(none)",
+        )
+        req = Request(url, headers=headers, method="HEAD")
+        response: HTTPResponse = build_opener(HTTPAllow404Handler).open(req)
+        if "X-Exodus-Version" in response.headers:
+            LOG.debug("Test succeeded")
+            return
+
+        raise RuntimeError("no X-Exodus-Version found in response")
+    except Exception:
+        traceback.print_exc()
+        print(
+            (
+                "Signature check failed. Please confirm the correct key, "
+                "key ID and URL were provided, or use `--skip-test' to ignore "
+                "this error."
+            ),
+            file=sys.stderr,
+        )
+        sys.exit(20)
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument(
+        "--key",
+        help="Path to private key used to generate signature",
+        required=True,
+    )
+    p.add_argument(
+        "--key-id",
+        help="Key ID for corresponding CloudFront public key",
+        required=True,
+    )
+    p.add_argument(
+        "--expire-days",
+        help=(
+            "How long should the signature be valid for, in days; "
+            "non-integer and negative values may be used"
+        ),
+        type=float,
+        default=1.0,
+    )
+    p.add_argument(
+        "--skip-test",
+        help="Do not test the generated signature",
+        action="store_true",
+    )
+    p.add_argument("--debug", help="Verbose logging", action="store_true")
+
+    group = p.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "--url", help="Generate a signed URL using the given URL as input"
+    )
+    group.add_argument(
+        "--cookie",
+        help="Generate signed cookies using the given path as a base",
+    )
+
+    args = p.parse_args()
+
+    logging.basicConfig(level=logging.DEBUG if args.debug else logging.INFO)
+
+    signer_class = import_signer_class()
+    signer = signer_class(open(args.key).read(), args.key_id)
+
+    expires = datetime.utcnow() + timedelta(days=args.expire_days)
+
+    cookies = signer.cookies_for_policy(
+        append="",
+        resource=args.cookie or args.url,
+        date_less_than=expires,
+    )
+
+    if args.url:
+        if "?" in args.url:
+            raise ValueError(
+                "Provided URL must not contain query string component."
+            )
+
+        url = args.url + "?"
+        qs_components = []
+
+        # With signed URLs, the needed query string components are just the same as
+        # the cookie values but with no 'CloudFront-' prefix. So just reuse the
+        # cookies we've already generated.
+        for cookie in cookies:
+            assert cookie.startswith("CloudFront-")
+            qs_components.append(cookie[len("CloudFront-") :])
+
+        url = url + "&".join(qs_components)
+
+        if not args.skip_test:
+            test_request(url, [])
+
+        print(url)
+
+    if args.cookie:
+        if not args.skip_test:
+            test_request(args.cookie, cookies)
+        print(f"Cookie: {'; '.join(cookies)}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Something like this has been floating around JIRA comments for a while and used during testing. Add a proper script to handle it because we'll have an ongoing need to generate these signatures.

The script includes a self-test feature to ensure that trying to use the wrong key or ID for an environment will be detected.