### PR TITLE
pip-compile: use backtracking resolver to fix dependency resolution

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -133,14 +133,11 @@ addopts = -v
 relative_files = true
 
 [testenv:pip-compile]
-# Recompile all requirements .txt files using pip-compile.
-# Don't edit me - I'm deployed from a template.
 deps = pip-tools
 basepython = python3.9
 skip_install = true
 skipsdist = true
 commands =
-    pip-compile -U --generate-hashes requirements-fakefront.in
-    pip-compile -U --generate-hashes requirements.in
-    pip-compile -U --generate-hashes requirements-fakefront.in requirements.in test-requirements.in -o test-requirements.txt
-# end pip-compile
+    pip-compile -U --resolver=backtracking --generate-hashes requirements-fakefront.in
+    pip-compile -U --resolver=backtracking --generate-hashes requirements.in
+    pip-compile -U --resolver=backtracking --generate-hashes requirements-fakefront.in requirements.in test-requirements.in -o test-requirements.txt


### PR DESCRIPTION
The backtracking resolver will be the default in pip 7.0.0. With the legacy resolver, pip-compile currently fails with errors:

      There are incompatible versions in the resolved dependencies:
        packaging>=22.0 (from black==23.1.0->-r test-requirements.in (line 5))
        packaging (from pytest==7.2.1->-r test-requirements.in (line 1))
        packaging<22.0,>=21.0 (from safety==2.3.5->-r test-requirements.in (line 12))