### PR TITLE
Drop black from github actions CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
 -   repo: https://github.com/ambv/black
-    rev: 22.6.0
+    rev: 23.1.0
     hooks:
     - id: black
       language_version: python3.9
 -   repo: https://github.com/pycqa/isort/
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
     - id: isort
       language_version: python3.9

--- a/support/fakefront/lambdaio.py
+++ b/support/fakefront/lambdaio.py
@@ -31,7 +31,7 @@ class LambdaInput:
 
     def _new_request(self):
         headers = {}
-        for (key, value) in self._wsgi_environ.items():
+        for key, value in self._wsgi_environ.items():
             # e.g. HTTP_USER_AGENT => user-agent
             if key.startswith("HTTP_"):
                 key = key[len("HTTP_") :].lower()
@@ -58,7 +58,7 @@ class LambdaInput:
         assert self._response
 
         headers = {}
-        for (key, val) in self._response.headers.items():
+        for key, val in self._response.headers.items():
             # TODO: should we actually copy all of the headers from
             # origin or should it be filtered somehow? Should investigate
             # and copy what cloudfront does.

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -2,7 +2,6 @@ pytest
 mock
 more-itertools
 wcwidth
-black
 coveralls
 pylint
 pytest-cov

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,6 @@ allowlist_externals=sh
 commands=
     mypy --install-types --non-interactive -p exodus_lambda -p tests
 	sh -c 'pylint exodus_lambda; test $(( $? & (1|2|4|32) )) = 0'
-    black --check .
     isort --check .
 
 [testenv:cov]


### PR DESCRIPTION
"tox -e static" previously ran the black autoformatter using a version managed by pip-compile.

Problem: pre-commit also runs black, but this uses the version defined in the pre-commit config. If there are any differences in the black code style between the two versions of the tool, they will not both be able to pass.

This recently blocked dependency updates for this repo because a new release of black is available which has some incompatibilities with the version used by pre-commit.

Rather than trying to keep both versions in sync, it makes more sense to apply the tool in just one place; so let's drop it from tox & github actions and rely only on pre-commit.ci to both run the tool and manage the version of the tool.

This commit includes an update to the pre-commit hook versions so that pre-commit.ci will be able to pass.