### PR TITLE
Convert logging format to JSON [RHELDST-15699]

### DIFF
--- a/exodus_lambda/functions/base.py
+++ b/exodus_lambda/functions/base.py
@@ -4,6 +4,8 @@ import logging.config
 import os
 import re
 
+from .json_logging import JsonFormatter
+
 
 class LambdaBase(object):
     def __init__(self, logger_name="default", conf_file="lambda_config.json"):
@@ -38,9 +40,11 @@ class LambdaBase(object):
             logging.config.dictConfig(log_conf)
             root_logger = logging.getLogger()
             if log_conf and root_logger.handlers:
-                formatter_str = log_conf["formatters"]["default"]["format"]
-                formatter_date = log_conf["formatters"]["default"]["datefmt"]
-                formatter = logging.Formatter(formatter_str, formatter_date)
+                fmt = log_conf["formatters"]["default"]["format"]
+                datefmt = log_conf["formatters"]["default"]["datefmt"]
+                formatter = JsonFormatter(fmt, datefmt)
+                if not isinstance(formatter.fmt, dict):
+                    formatter = logging.Formatter(fmt, datefmt)
                 root_logger.handlers[0].setFormatter(formatter)
             self._logger = logging.getLogger(self._logger_name)
         return self._logger

--- a/exodus_lambda/functions/json_logging.py
+++ b/exodus_lambda/functions/json_logging.py
@@ -1,0 +1,54 @@
+import json
+import logging
+
+
+class JsonFormatter(logging.Formatter):
+    def __init__(self, fmt=None, datefmt="%Y-%m-%d %H:%M:%S"):
+        super().__init__()
+        self._fmt = fmt or {
+            "level": "levelname",
+            "time": "asctime",
+            "name": "name",
+            "message": "message",
+        }
+        self.dictfmt = None
+        self.datefmt = datefmt
+
+    @property
+    def fmt(self):
+        # If it doesn't look like JSON, fmt will always return NoneType.
+        # If it looks like JSON but is invalid, fmt will raise the appropriate error.
+        if not self.dictfmt:
+            if isinstance(self._fmt, dict):
+                self.dictfmt = self._fmt
+            elif isinstance(self._fmt, str) and "{" in self._fmt:
+                try:
+                    self.dictfmt = json.loads(self._fmt)
+                except json.JSONDecodeError:
+                    logging.getLogger().exception(
+                        "Unable to load JSON format: %s", self._fmt
+                    )
+                    raise
+        return self.dictfmt
+
+    def formatMessage(self, record):
+        return {k: record.__dict__[v] for k, v in self.fmt.items()}
+
+    def format(self, record):
+        record.message = record.getMessage()
+
+        if "asctime" in self.fmt.values():
+            record.asctime = self.formatTime(record, self.datefmt)
+
+        d = self.formatMessage(record)
+
+        if record.exc_info:
+            record.exc_text = self.formatException(record.exc_info)
+
+        if record.exc_text:
+            d["exc_info"] = record.exc_text
+
+        if record.stack_info:
+            d["stack_info"] = self.formatStack(record.stack_info)
+
+        return json.dumps(d)

--- a/exodus_lambda/functions/origin_response.py
+++ b/exodus_lambda/functions/origin_response.py
@@ -17,12 +17,12 @@ class OriginResponse(LambdaBase):
         request = event["Records"][0]["cf"]["request"]
         response = event["Records"][0]["cf"]["response"]
 
-        self.logger.info(
-            "The request value for origin_response beginning is '%s'",
+        self.logger.debug(
+            "Original request value for origin_response: %s",
             json.dumps(request, indent=4, sort_keys=True),
         )
-        self.logger.info(
-            "The response value for origin_response beginning is '%s'",
+        self.logger.debug(
+            "Original response value for origin_response: %s",
             json.dumps(response, indent=4, sort_keys=True),
         )
 

--- a/scripts/mk-config
+++ b/scripts/mk-config
@@ -3,7 +3,7 @@ set -e
 
 export ORIGIN_RESPONSE_LOGGER_LEVEL=${ORIGIN_RESPONSE_LOGGER_LEVEL:-WARNING}
 export ORIGIN_REQUEST_LOGGER_LEVEL=${ORIGIN_REQUEST_LOGGER_LEVEL:-WARNING}
-export EXODUS_LOG_FORMAT="${EXODUS_LOG_FORMAT:-%(asctime)s - %(levelname)s - %(aws_request_id)s - %(message)s}"
+export EXODUS_LOG_FORMAT="${EXODUS_LOG_FORMAT:-{\"level\":\"levelname\",\"time\":\"asctime\",\"aws-request-id\":\"aws_request_id\",\"message\":\"message\"}}"
 export EXODUS_HEADERS_MAX_AGE=${EXODUS_HEADERS_MAX_AGE:-600}
 export EXODUS_CONFIG_CACHE_TTL=${EXODUS_CONFIG_CACHE_TTL:-2}
 export EXODUS_COOKIE_TTL=${EXODUS_COOKIE_TTL:-720}

--- a/tests/test_utils/utils.py
+++ b/tests/test_utils/utils.py
@@ -33,9 +33,6 @@ def generate_test_config(conf=CONF_FILE):
     conf["config_table"]["name"] = "test-config-table"
 
     # logging
-    conf["logging"]["formatters"]["default"][
-        "format"
-    ] = "[%(levelname)s] - %(message)s\n"
     conf["logging"]["loggers"]["origin-response"]["level"] = "DEBUG"
     conf["logging"]["loggers"]["origin-request"]["level"] = "DEBUG"
     conf["logging"]["loggers"]["default"]["level"] = "DEBUG"


### PR DESCRIPTION
For compatibility with splunk, exodus-lambda must output machine-readable logs. This commit adds and attaches a JSON log handler with fields for log level, logger name, timestamp, and message.

Additionally, several log messages were updated for readability and some log levels were adjusted.