### PR TITLE
Add timeout to test_exodus requests for bandit check complaints

### DIFF
--- a/tests/integration/test_exodus.py
+++ b/tests/integration/test_exodus.py
@@ -6,6 +6,7 @@ import pytest
 from ..test_utils.utils import generate_test_cookies
 
 TEST_COOKIES = generate_test_cookies()
+TEST_TIMEOUT = 7200
 
 
 def test_exodus_basic(cdn_test_url, requests_session):
@@ -14,7 +15,7 @@ def test_exodus_basic(cdn_test_url, requests_session):
         + "/content/aus/rhel/server/6/6.5/x86_64/os/Packages/c/cpio-2.10-12.el6_5.x86_64.rpm"
     )
 
-    r = requests_session.get(url, cookies=TEST_COOKIES)
+    r = requests_session.get(url, cookies=TEST_COOKIES, timeout=TEST_TIMEOUT)
     print(json.dumps(dict(r.headers), indent=2))
     assert r.status_code == 200
     assert "cache-control" not in r.headers
@@ -25,7 +26,7 @@ def test_header_not_exist_file(cdn_test_url, requests_session):
         cdn_test_url
         + "/content/aus/rhel/server/6/6.5/x86_64/os/Packages/c/cpio-2.10-12.el6_5.x86_64.rpm_not_exist"  # noqa: E501
     )
-    r = requests_session.get(url, cookies=TEST_COOKIES)
+    r = requests_session.get(url, cookies=TEST_COOKIES, timeout=TEST_TIMEOUT)
     print(json.dumps(dict(r.headers), indent=2))
     assert r.status_code == 404
     assert "cache-control" not in r.headers
@@ -43,7 +44,7 @@ testdata_cache_control_path = [
 @pytest.mark.parametrize("testdata_path", testdata_cache_control_path)
 def test_header_cache_control(cdn_test_url, requests_session, testdata_path):
     url = cdn_test_url + testdata_path
-    r = requests_session.get(url, cookies=TEST_COOKIES)
+    r = requests_session.get(url, cookies=TEST_COOKIES, timeout=TEST_TIMEOUT)
     print(json.dumps(dict(r.headers), indent=2))
     assert r.status_code == 200
     assert re.match("^max-age=[0-9]+$", r.headers["cache-control"])
@@ -55,7 +56,9 @@ def test_header_want_digest_GET(cdn_test_url, requests_session):
         cdn_test_url
         + "/content/dist/rhel/server/7/7.2/x86_64/rhev-mgmt-agent/3/os/repodata/repomd.xml"
     )
-    r = requests_session.get(url, headers=headers, cookies=TEST_COOKIES)
+    r = requests_session.get(
+        url, headers=headers, cookies=TEST_COOKIES, timeout=TEST_TIMEOUT
+    )
     print(json.dumps(dict(r.headers), indent=2))
     assert r.status_code == 200
     assert (
@@ -70,7 +73,9 @@ def test_header_want_digest_HEAD(cdn_test_url, requests_session):
         cdn_test_url
         + "/content/dist/rhel/server/7/7.2/x86_64/rhev-mgmt-agent/3/os/repodata/repomd.xml"
     )
-    r = requests_session.head(url, headers=headers, cookies=TEST_COOKIES)
+    r = requests_session.head(
+        url, headers=headers, cookies=TEST_COOKIES, timeout=TEST_TIMEOUT
+    )
     print(json.dumps(dict(r.headers), indent=2))
     assert r.status_code == 200
     assert (
@@ -104,7 +109,7 @@ def test_content_type_header_GET(
     cdn_test_url, requests_session, testdata_path
 ):
     url = cdn_test_url + testdata_path
-    r = requests_session.get(url, cookies=TEST_COOKIES)
+    r = requests_session.get(url, cookies=TEST_COOKIES, timeout=TEST_TIMEOUT)
     print(json.dumps(dict(r.headers), indent=2))
     assert r.status_code == 200
     assert_content_type(url, r.headers["Content-Type"])
@@ -115,7 +120,7 @@ def test_content_type_header_HEAD(
     cdn_test_url, requests_session, testdata_path
 ):
     url = cdn_test_url + testdata_path
-    r = requests_session.head(url, cookies=TEST_COOKIES)
+    r = requests_session.head(url, cookies=TEST_COOKIES, timeout=TEST_TIMEOUT)
     print(json.dumps(dict(r.headers), indent=2))
     assert r.status_code == 200
     assert_content_type(url, r.headers["Content-Type"])
@@ -134,7 +139,9 @@ testdata_origin_alias_path = [
 def test_origin_path_alias(cdn_test_url, requests_session, testdata_path):
     headers = {"want-digest": "id-sha-256"}
     url = cdn_test_url + testdata_path
-    r = requests_session.head(url, headers=headers, cookies=TEST_COOKIES)
+    r = requests_session.head(
+        url, headers=headers, cookies=TEST_COOKIES, timeout=TEST_TIMEOUT
+    )
     print(json.dumps(dict(r.headers), indent=2))
     assert r.status_code == 200
     assert (
@@ -153,7 +160,9 @@ testdata_rhui_alias_path_aus = [
 def test_rhui_path_alias_aus(cdn_test_url, requests_session, testdata_path):
     headers = {"want-digest": "id-sha-256"}
     url = cdn_test_url + testdata_path
-    r = requests_session.head(url, headers=headers, cookies=TEST_COOKIES)
+    r = requests_session.head(
+        url, headers=headers, cookies=TEST_COOKIES, timeout=TEST_TIMEOUT
+    )
     print(json.dumps(dict(r.headers), indent=2))
     assert r.status_code == 200
     assert (
@@ -172,7 +181,9 @@ testdata_rhui_alias_path_rhel8 = [
 def test_rhui_path_alias_rhel8(cdn_test_url, requests_session, testdata_path):
     headers = {"want-digest": "id-sha-256"}
     url = cdn_test_url + testdata_path
-    r = requests_session.head(url, headers=headers, cookies=TEST_COOKIES)
+    r = requests_session.head(
+        url, headers=headers, cookies=TEST_COOKIES, timeout=TEST_TIMEOUT
+    )
     print(json.dumps(dict(r.headers), indent=2))
     assert r.status_code == 200
     assert (
@@ -191,7 +202,9 @@ testdata_releasever_alias_rhel6 = [
 def test_releasever_alias_rhel6(cdn_test_url, requests_session, testdata_path):
     headers = {"want-digest": "id-sha-256"}
     url = cdn_test_url + testdata_path
-    r = requests_session.head(url, headers=headers, cookies=TEST_COOKIES)
+    r = requests_session.head(
+        url, headers=headers, cookies=TEST_COOKIES, timeout=TEST_TIMEOUT
+    )
     print(json.dumps(dict(r.headers), indent=2))
     assert r.status_code == 200
     assert (
@@ -208,7 +221,7 @@ testdata_no_content_type = [
 @pytest.mark.parametrize("testdata_path", testdata_no_content_type)
 def test_no_content_type(cdn_test_url, requests_session, testdata_path):
     url = cdn_test_url + testdata_path
-    r = requests_session.get(url, cookies=TEST_COOKIES)
+    r = requests_session.get(url, cookies=TEST_COOKIES, timeout=TEST_TIMEOUT)
     print(json.dumps(dict(r.headers), indent=2))
     assert r.status_code == 200
     assert r.headers["Content-Type"] == "application/octet-stream"
@@ -222,6 +235,6 @@ testdata_absent_item = [
 @pytest.mark.parametrize("testdata_path", testdata_absent_item)
 def test_absent_item(cdn_test_url, requests_session, testdata_path):
     url = cdn_test_url + testdata_path
-    r = requests_session.get(url, cookies=TEST_COOKIES)
+    r = requests_session.get(url, cookies=TEST_COOKIES, timeout=TEST_TIMEOUT)
     print(json.dumps(dict(r.headers), indent=2))
     assert r.status_code == 404


### PR DESCRIPTION
The newest version of Bandit, 1.7.5, complains about requests without timeouts. It's probably best to comply, so this commit adds a global timeout of 2 hours to requests in tests/integration/test_exodus.py