### PR TITLE
Logging: record milliseconds in timestamp by default [RHELDST-16619]

### DIFF
--- a/configuration/lambda_config.template
+++ b/configuration/lambda_config.template
@@ -25,9 +25,7 @@
     "incremental": "True",
     "disable_existing_loggers": "False",
     "formatters": {
-      "default": {
-        "datefmt": "%Y-%m-%d %H:%M:%S"
-      }
+      "default": {}
     },
     "loggers": {
       "origin-response": {

--- a/exodus_lambda/functions/json_logging.py
+++ b/exodus_lambda/functions/json_logging.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 import logging
 
@@ -13,8 +14,24 @@ class JsonFormatter(logging.Formatter):
             "request": "request",
             "response": "response",
         }
-        self.datefmt = datefmt or "%Y-%m-%d %H:%M:%S"
-        self.dictfmt = None
+        self.datefmt = datefmt
+
+    # Appended '_' on 'converter' because mypy doesn't approve of
+    # overwriting a base class variable with another type.
+    converter_ = datetime.datetime.fromtimestamp
+
+    default_time_format = "%Y-%m-%d %H:%M:%S"
+    default_msec_format = "%s.%03d"
+
+    def formatTime(self, record, datefmt=None):
+        ct = self.converter_(record.created, datetime.timezone.utc)
+        if datefmt:
+            s = ct.strftime(datefmt)
+        else:
+            s = ct.strftime(self.default_time_format)
+            if self.default_msec_format:
+                s = self.default_msec_format % (s, record.msecs)
+        return s
 
     def formatMessage(self, record):
         return {k: record.__dict__.get(v) for k, v in self.fmt.items()}

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -9,3 +9,4 @@ mypy
 importlib-metadata
 bandit
 safety
+freezegun

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -279,6 +279,10 @@ exceptiongroup==1.1.1 \
     --hash=sha256:232c37c63e4f682982c8b6459f33a8981039e5fb8756b2074364e5055c498c9e \
     --hash=sha256:d484c3090ba2889ae2928419117447a14daf3c1231d5e30d0aae34f354f01785
     # via pytest
+freezegun==1.2.2 \
+    --hash=sha256:cd22d1ba06941384410cd967d8a99d5ae2442f57dfafeff2fda5de8dc5c05446 \
+    --hash=sha256:ea1b963b993cb9ea195adbd893a48d573fda951b0da64f60883d7e988b606c9f
+    # via -r test-requirements.in
 frozendict==2.3.7 \
     --hash=sha256:01c01ba4b1b77aa4385f27b2514ac284af42b331eeb4b853a05cf39145853e5f \
     --hash=sha256:0f63205aebde38645dce0732f90b59dace205104f2284fcee42bedbafb2068f3 \
@@ -493,7 +497,9 @@ pytest-cov==4.0.0 \
 python-dateutil==2.8.2 \
     --hash=sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86 \
     --hash=sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9
-    # via botocore
+    # via
+    #   botocore
+    #   freezegun
 pyyaml==6.0 \
     --hash=sha256:01b45c0191e6d66c470b6cf1b9531a771a83c1c4208272ead47a3ae4f2f603bf \
     --hash=sha256:0283c35a6a9fbf047493e3a0ce8d79ef5030852c51e9d911a27badfde0605293 \

--- a/tests/functions/test_base.py
+++ b/tests/functions/test_base.py
@@ -1,7 +1,10 @@
+import copy
+import json
 import logging
 import os
 
 import pytest
+from freezegun import freeze_time
 
 from exodus_lambda.functions.base import LambdaBase
 
@@ -9,6 +12,7 @@ from ..test_utils.utils import generate_test_config
 
 CONF_FILE = os.environ.get("EXODUS_LAMBDA_CONF_FILE")
 TEST_CONF = generate_test_config()
+MOCKED_DT = "2023-04-26 14:43:13.570034+00:00"
 
 
 def test_base_handler():
@@ -65,7 +69,44 @@ def test_root_logger_without_handlers(caplog):
     assert "warning message" not in caplog.text
 
 
-def test_json_handler_stack_info(caplog):
+def test_json_logger_stack_info(caplog):
     base_obj = LambdaBase(conf_file=TEST_CONF)
     base_obj.logger.exception("oops", stack_info=True)
     assert '"stack_info": "Stack (most recent call last)' in caplog.text
+
+
+@freeze_time(MOCKED_DT)
+def test_json_logger_timestamp(caplog):
+    LambdaBase(conf_file=TEST_CONF).logger.info("Works!")
+
+    # Logged timestamp should show milliseconds by default
+    assert json.loads(caplog.text) == {
+        "level": "INFO",
+        "time": "2023-04-26 14:43:13.570",
+        "aws-request-id": None,
+        "message": "Works!",
+        "request": None,
+        "response": None,
+    }
+
+
+@freeze_time(MOCKED_DT)
+def test_json_logger_configurable_datefmt(caplog):
+    """Ensure logger's datefmt is configurable"""
+
+    new_datefmt = "%H:%M on %A, %B %d, %Y"
+
+    conf = copy.deepcopy(TEST_CONF)
+    conf["logging"]["formatters"]["default"]["datefmt"] = new_datefmt
+
+    LambdaBase(conf_file=conf).logger.info("Works!")
+
+    # Logged timestamp should be formatted as new_datefmt
+    assert json.loads(caplog.text) == {
+        "level": "INFO",
+        "time": "14:43 on Wednesday, April 26, 2023",
+        "aws-request-id": None,
+        "message": "Works!",
+        "request": None,
+        "response": None,
+    }


### PR DESCRIPTION
Overrides logging's formatTime to use datetime objects and a period
separator for msec. Removes the datefmt set in the lambda config template
but the field remains configurable should the client/service choose.
All log times are now in UTC timezone.