### PR TITLE
reftest: support publishing via exodus-gw

### DIFF
--- a/support/reftest/reftest
+++ b/support/reftest/reftest
@@ -12,16 +12,25 @@ import json
 import os
 import sys
 import tempfile
-from datetime import datetime
+import time
+from datetime import datetime, timezone
+from typing import Optional
 
 import boto3
 import requests
 import yaml
+from botocore.config import Config
+from botocore.exceptions import ClientError
 from tqdm import tqdm
 
 DATA_DIR = os.path.dirname(__file__)
 
 ENDPOINT_URL = os.environ.get("EXODUS_AWS_ENDPOINT_URL") or None
+
+
+def die(message: str):
+    print(message, file=sys.stderr)
+    sys.exit(4)
 
 
 class DBHandler:
@@ -119,6 +128,235 @@ class S3Handler:
             bar.close()
 
 
+class PublishBackend:
+    """Base class for different publish backends."""
+
+    def start_publish(self):
+        """Start a publish.
+
+        May do nothing if backend does not have the concept of grouping
+        items into a publish object.
+        """
+
+    def commit(self):
+        """Commit a publish previously started via start_publish.
+
+        May do nothing if backend does not have the concept of grouping
+        items into a publish object.
+        """
+
+    def set_exodus_config(self, config: dict):
+        """Set the current exodus-config to the given dict."""
+
+        # subclass must implement
+        raise NotImplementedError()
+
+    def add_item(
+        self,
+        local_path: str,
+        remote_path: str,
+        sha256sum: str,
+        content_type: Optional[str],
+    ):
+        """Add a single item onto the current publish:
+
+        local_path   -- path to a local file
+        remote_path  -- path used for published content on CDN
+        sha256sum    -- checksum of the content
+        content_type -- MIME type of uploaded content
+        """
+        # subclass must implement
+        raise NotImplementedError()
+
+
+class AWSPublishBackend(PublishBackend):
+    """Publish backend using low-level access to AWS resources."""
+
+    def __init__(self, opts: argparse.Namespace):
+        session = boto3.Session(
+            aws_access_key_id=opts.aws_access_id,
+            aws_secret_access_key=opts.aws_access_key,
+            aws_session_token=opts.aws_session_token,
+            region_name=opts.default_region,
+        )
+
+        if not opts.table:
+            die("Missing --table argument for AWS.")
+        if not opts.bucket:
+            die("Missing --bucket argument for AWS.")
+        if not opts.config_table:
+            die("Missing --config-table for AWS.")
+
+        self.db = DBHandler(
+            table=opts.table, config_table=opts.config_table, session=session
+        )
+        self.s3 = S3Handler(bucket=opts.bucket, session=session)
+
+    def add_item(
+        self,
+        local_path: str,
+        remote_path: str,
+        sha256sum: str,
+        content_type: Optional[str],
+    ):
+        # push test data to s3 and dynamodb
+        self.s3.upload_from_localfile(local_path, sha256sum)
+        self.db.put_item(
+            remote_path,
+            sha256sum,
+            from_date=str(datetime.now(timezone.utc)),
+            content_type=content_type,
+        )
+
+    def set_exodus_config(self, config: dict):
+        self.db.put_config(config)
+
+
+class GWPublishBackend(PublishBackend):
+    """Publish backend using exodus-gw."""
+
+    def __init__(self, opts: argparse.Namespace):
+        self.session = requests.Session()
+        self.session.cert = (opts.gw_cert, opts.gw_key)
+
+        if not opts.gw_env:
+            die("Missing --gw-env.")
+        if not opts.gw_url:
+            die("Missing --gw-url.")
+
+        self.env = opts.gw_env
+        self.url = opts.gw_url
+        while self.url.endswith("/"):
+            self.url = self.url[:-1]
+
+        # https://release-engineering.github.io/exodus-gw/api.html#section/Using-boto3-with-the-upload-API
+        s3 = boto3.resource(
+            "s3",
+            endpoint_url=f"{self.url}/upload",
+            aws_access_key_id="dummy",
+            aws_secret_access_key="dummy",
+            config=Config(client_cert=(opts.gw_cert, opts.gw_key)),
+        )
+        self.s3_bucket = s3.Bucket(opts.gw_env)
+
+        self.publish_url = None
+        self.commit_url = None
+
+    def start_publish(self):
+        create_url = f"{self.url}/{self.env}/publish"
+
+        response = self.session.post(create_url)
+        response.raise_for_status()
+
+        body = response.json()
+        self.publish_url = self.url + body["links"]["self"]
+        self.commit_url = self.url + body["links"]["commit"]
+
+        print("Started publish:", self.publish_url)
+
+    def commit(self):
+        print("Committing:", self.publish_url)
+
+        response = self.session.post(self.commit_url)
+        response.raise_for_status()
+
+        body = response.json()
+        task_url = self.url + body["links"]["self"]
+        self.await_task(task_url)
+
+    def await_task(self, task_url: str):
+        print("Awaiting task:", task_url)
+
+        while True:
+            response = self.session.get(task_url)
+            response.raise_for_status()
+
+            state = response.json()["state"]
+            print("   ", state)
+            if state == "FAILED":
+                die(f"exodus-gw task failed: {task_url}")
+            if state == "COMPLETE":
+                break
+            time.sleep(10)
+
+    def add_item(
+        self,
+        local_path: str,
+        remote_path: str,
+        sha256sum: str,
+        content_type: Optional[str],
+    ):
+        # First ensure the object is in S3.
+        object = self.s3_bucket.Object(sha256sum)
+
+        try:
+            object.load()
+            print("Already in S3:", sha256sum)
+        except ClientError as exc:
+            if exc.response["Error"]["Code"] == "404":
+                # The normal case for a missing object, so upload it.
+                object.upload_file(local_path)
+                print(f"Uploaded: {sha256sum}")
+            else:
+                # Anything else, we don't know what happened, propagate.
+                raise
+
+        # Next add it to the publish.
+        response = self.session.put(
+            self.publish_url,
+            json=[
+                dict(
+                    web_uri=remote_path,
+                    object_key=sha256sum,
+                    content_type=content_type,
+                )
+            ],
+        )
+        response.raise_for_status()
+
+        print(f"Added to publish: {remote_path} => {sha256sum}")
+
+    def set_exodus_config(self, config: dict):
+        deploy_config_url = f"{self.url}/{self.env}/deploy-config"
+
+        print("Deploying config:", config)
+        response = self.session.post(deploy_config_url, json=config)
+        response.raise_for_status()
+
+        task_url = self.url + response.json()["links"]["self"]
+        self.await_task(task_url)
+
+
+def get_publish_backend(opts: argparse.Namespace) -> PublishBackend:
+    """Obtain and return a PublishBackend appropriate for the arguments
+    passed by the user.
+    """
+    if opts.bucket or opts.table or opts.config_table:
+        # AWS mode.
+        if opts.gw_url or opts.gw_env:
+            die(
+                "You provided both AWS and exodus-gw arguments. "
+                "Provide only one or the other."
+            )
+
+        return AWSPublishBackend(opts)
+
+    if opts.gw_url or opts.gw_env:
+        # GW mode.
+        if opts.bucket or opts.table or opts.config_table:
+            die(
+                "You provided both AWS and exodus-gw arguments. "
+                "Provide only one or the other."
+            )
+        return GWPublishBackend(opts)
+
+    # broken mode
+    die(
+        "You must provide either AWS arguments (--bucket, ...) or "
+        "exodus-gw arguments (--gw-url, ...). See --help."
+    )
+
+
 def parse_aws_session(parser):
     parser.add_argument(
         "--aws-access-id",
@@ -173,7 +411,7 @@ def parse_cdn_certs(parser):
 def parse_args():
     root_parser = argparse.ArgumentParser(description=__doc__)
     subparsers = root_parser.add_subparsers(
-        dest="command", help="reference test data operations"
+        dest="command", help="reference test data operations", required=True
     )
     # parser for prepare operation
     parser_prepare = subparsers.add_parser(
@@ -184,27 +422,48 @@ def parse_args():
          e.g. $./reftest prepare --bucket exodus-bucket --table exodus-table --config-table exodus-config
         """,
     )
+
     parser_prepare.add_argument(
-        "--release-date",
-        default=None,
-        help="Date on which the content will be made available.",
+        "--deploy-config",
+        action="store_true",
+        help="Also deploy CDN config (dangerous!)",
     )
-    parse_aws_session(parser_prepare)
+
     parse_cdn_certs(parser_prepare)
-    parser_prepare.add_argument(
+
+    aws_group = parser_prepare.add_argument_group("AWS arguments")
+    parse_aws_session(aws_group)
+    aws_group.add_argument(
         "--bucket",
-        required=True,
         help="The AWS S3 bucket used to store test data",
     )
-    parser_prepare.add_argument(
+    aws_group.add_argument(
         "--table",
-        required=True,
         help="The AWS dynamoDB used to store test data",
     )
-    parser_prepare.add_argument(
+    aws_group.add_argument(
         "--config-table",
-        required=True,
         help="The AWS dynamoDB used to store Exodus config",
+    )
+
+    gw_group = parser_prepare.add_argument_group("exodus-gw arguments")
+    gw_group.add_argument(
+        "--gw-url",
+        help="Base URL of an exodus-gw instance",
+    )
+    gw_group.add_argument(
+        "--gw-env",
+        help="Environment name (e.g. pre, live)",
+    )
+    gw_group.add_argument(
+        "--gw-cert",
+        help="Path to a cert for exodus-gw auth",
+        default=os.path.expandvars("$HOME/certs/$USER.crt"),
+    )
+    gw_group.add_argument(
+        "--gw-key",
+        help="Path to the key corresponding with --gw-cert",
+        default=os.path.expandvars("$HOME/certs/$USER.key"),
     )
 
     return root_parser.parse_args()
@@ -255,15 +514,15 @@ def download_to_local(url, key_path, cert_path, cacert_path):
         return temp_file, sha256.hexdigest()
 
 
-def prepare(db_client, s3_client, config, opt):
+def prepare(publisher: PublishBackend, config, opt):
+    publisher.start_publish()
     for item in config.test_data:
         if not item.get("deploy", True):
             # skip items that specify deploy=false
             continue
 
         if item.get("state") == "absent":
-            # skip all the downloading and checking when absent=true
-            db_client.put_absent_item(item["path"])
+            # Just don't put any item.
             continue
 
         url = config.prod_cdn_url + item["path"]
@@ -283,20 +542,21 @@ def prepare(db_client, s3_client, config, opt):
             )
             return False
 
-        # push test data to s3 and dynamodb
-        s3_client.upload_from_localfile(temp_file.name, cdn_data_checksum)
-        db_client.put_item(
-            item["path"],
-            cdn_data_checksum,
-            from_date=opt.release_date,
-            content_type=item.get("content-type", None),
+        publisher.add_item(
+            local_path=temp_file.name,
+            remote_path=item["path"],
+            sha256sum=cdn_data_checksum,
+            content_type=item["content-type"],
         )
 
         # delete the NamedTemporaryFile
         temp_file.close()
 
-    # deploy Exodus config to config table
-    db_client.put_config(config.test_config)
+    publisher.commit()
+
+    if opt.deploy_config:
+        # deploy Exodus config to config table
+        publisher.set_exodus_config(config.test_config)
 
     return True
 
@@ -304,22 +564,11 @@ def prepare(db_client, s3_client, config, opt):
 def main():
     config = load_config()
     opt = parse_args()
-
-    session = boto3.Session(
-        aws_access_key_id=opt.aws_access_id,
-        aws_secret_access_key=opt.aws_access_key,
-        aws_session_token=opt.aws_session_token,
-        region_name=opt.default_region,
-    )
-
-    db_client = DBHandler(
-        table=opt.table, config_table=opt.config_table, session=session
-    )
-    s3_client = S3Handler(bucket=opt.bucket, session=session)
+    publisher = get_publish_backend(opt)
 
     res = False
     if opt.command == "prepare":
-        res = prepare(db_client, s3_client, config, opt)
+        res = prepare(publisher, config, opt)
 
     if res:
         print("{} operation has finished successfully!".format(opt.command))


### PR DESCRIPTION
The reftest script previously worked only by accessing S3 and DynamoDB directly. We really ought to avoid that as much as possible, especially on stage and production environments. Ideally we should not even have the necessary credentials for that.

Let's support deploying reftest data via exodus-gw. That's safer, will be logged appropriately and so on.

The primary motivation here is to make it possible to more safely provision reftest data to newly deployed stage and production environments, though a few other changes relating to safety were made as well:

- don't deploy "absent" items - there is no need to, and it kinda defeats the purpose. e.g. the reftest entry for "does-not-exist.iso" is supposed to test what happens if you query content which doesn't exist... not if you query content which has been explicitly marked absent, which is subtly different.

- don't deploy exodus-config by default. I don't think this should have been included in the default reftest steps. Most of the reftest data represents some invariants which should always be true and should be safe to deploy on a live environment. exodus-config is different in that the config is expected to change over time, and deploying a wrong config to a live environment can break the CDN completely.

- don't accept a --release-date argument. exodus-gw doesn't support it, and I see no reason to let the user control this anyway; there is no use-case for deploying reftest data in the future, and allowing the user to provide this argument opens the possibility of them providing an invalid argument (e.g. timestamps of the incorrect format, or strings which are not valid timestamps at all).