### PR TITLE
logging: ensure JSON logs include logger name

### DIFF
--- a/exodus_lambda/functions/json_logging.py
+++ b/exodus_lambda/functions/json_logging.py
@@ -8,6 +8,7 @@ class JsonFormatter(logging.Formatter):
         super().__init__()
         self.fmt = {
             "level": "levelname",
+            "logger": "name",
             "time": "asctime",
             "aws-request-id": "aws_request_id",
             "message": "message",

--- a/tests/functions/test_base.py
+++ b/tests/functions/test_base.py
@@ -85,6 +85,7 @@ def test_json_logger_timestamp(caplog):
         "time": "2023-04-26 14:43:13.570",
         "aws-request-id": None,
         "message": "Works!",
+        "logger": "default",
         "request": None,
         "response": None,
     }
@@ -107,6 +108,7 @@ def test_json_logger_configurable_datefmt(caplog):
         "time": "14:43 on Wednesday, April 26, 2023",
         "aws-request-id": None,
         "message": "Works!",
+        "logger": "default",
         "request": None,
         "response": None,
     }

--- a/tests/functions/test_origin_request.py
+++ b/tests/functions/test_origin_request.py
@@ -150,6 +150,7 @@ def test_origin_request_fail_uri_validation(caplog):
         "time": mock.ANY,
         "aws-request-id": None,
         "message": "uri exceeds length limits: %s" % ("o" * 2001),
+        "logger": "origin-request",
         "request": None,
         "response": None,
     }
@@ -176,6 +177,7 @@ def test_origin_request_fail_querystring_validation(caplog):
         "time": mock.ANY,
         "aws-request-id": None,
         "message": "querystring exceeds length limits: %s" % ("o" * 2001),
+        "logger": "origin-request",
         "request": None,
         "response": None,
     }

--- a/tests/functions/test_origin_response.py
+++ b/tests/functions/test_origin_response.py
@@ -130,6 +130,7 @@ def test_origin_response_logger(caplog):
         "time": mock.ANY,
         "aws-request-id": None,
         "message": "Incoming event for origin_response",
+        "logger": "origin-response",
         "request": {
             "headers": {
                 "exodus-original-uri": [
@@ -148,6 +149,7 @@ def test_origin_response_logger(caplog):
         "time": mock.ANY,
         "aws-request-id": None,
         "message": "Completed response processing",
+        "logger": "origin-response",
         "request": {
             "headers": {
                 "exodus-original-uri": [


### PR DESCRIPTION
When we moved to JSON logging, the format adopted did not include the logger's name anywhere. That's a problem since, if we can't tell which logger produced which message, it'll sometimes be impossible to tell where a message came from and we will not be able to decide which loggers to enable/disable.

Change it to ensure logger name appears in a field, as in example:

    {"level": "DEBUG",
     "logger": "botocore.retryhandler",
     "time": "2023-05-23 23:30:19.194",
     "aws-request-id": null,
     "message": "No retry needed.",
     "request": null,
     "response": null}