### PR TITLE
Fix logging type error in lambda_config.template

### DIFF
--- a/configuration/lambda_config.template
+++ b/configuration/lambda_config.template
@@ -22,8 +22,7 @@
   "index_filename": "$EXODUS_INDEX_FILENAME",
   "logging": {
     "version": 1,
-    "incremental": "True",
-    "disable_existing_loggers": "False",
+    "incremental": true,
     "formatters": {
       "default": {}
     },


### PR DESCRIPTION
The config template declared:

    "incremental: "True",
    "disable_existing_loggers": "False",

Note the quotes around True/False. This is declaring *string* values, not *booleans* as intended.

It happened to not break anything for two reasons:

- per python code at [1], the value is used as "if incremental:", and a string value of "True" is truthy, so it works the same as if it were actually the boolean True.

- per docs at [2], the value of "disable_existing_loggers" is ignored if incremental is True. So, while the string value of "False" is truthy and would have caused things not to work as expected, in reality the value written here was never accessed and there was never a need to set a value in the first place.

Hence this commit is not fixing any real bug, and is only eliminating the type error to reduce confusion.

[1] https://github.com/python/cpython/blob/12f1581b0c43f40a792c188e17d2dea2357debb3/Lib/logging/config.py#LL517C38-L517C38
[2] https://docs.python.org/3/library/logging.config.html#logging-config-dictschema