### PR TITLE
Tweak arguments for safety tool

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ commands=
 [testenv:safety]
 usedevelop=true
 commands=
-	safety check --full-report
+	safety check --output json {posargs}
 
 [testenv:docs]
 use_develop=true


### PR DESCRIPTION
Switch from full-report to the json output. This is better to prove that the tool actually checked something, since it shows every package it found along with their version. It's still quite readable too, being pretty-printed.

Additionally, it is generally useful to accept additional arguments, so do that via {posargs}.