### PR TITLE
Refactor/fix multi-region handling [RHELDST-15297]

### DIFF
--- a/configuration/lambda_config.template
+++ b/configuration/lambda_config.template
@@ -17,6 +17,7 @@
     "max_age": $EXODUS_HEADERS_MAX_AGE
   },
   "secret_arn": "$EXODUS_SECRET_ARN",
+  "secret_region": "us-east-1",
   "key_id": "$EXODUS_KEY_ID",
   "lambda_version": "$EXODUS_LAMBDA_VERSION",
   "index_filename": "$EXODUS_INDEX_FILENAME",

--- a/docs/schemas/raw/lambda_config.yaml
+++ b/docs/schemas/raw/lambda_config.yaml
@@ -75,9 +75,14 @@ properties:
     maxLength: 500
     minLength: 1
 
+  secret_region:
+    type: string
+    description: Region used for connections to Secrets Manager
+    $ref: '#/definitions/aws_region'
+
 required:
-# In practice, we provide all properties in the config file all the time,
-# so we list everything as required.
+# In practice, we provide most properties in the config file all the time,
+# so we list them as required.
 #
 # It is possible that the code applies some defaults and so some of
 # these aren't truly required. This was not investigated when the schema

--- a/exodus_lambda/functions/db.py
+++ b/exodus_lambda/functions/db.py
@@ -1,0 +1,102 @@
+import logging
+from typing import Any, Optional
+
+import boto3
+
+LOG = logging.getLogger("exodus_lambda")
+
+
+class QueryHelper:
+    """A helper to perform DynamoDB queries with failover between regions."""
+
+    def __init__(self, conf: dict[str, Any], endpoint_url: Optional[str]):
+        self._conf = conf
+        self._endpoint_url = endpoint_url
+        self._clients: dict[str, Any] = {}
+
+    def _client(self, region: str):
+        # Return lazy-constructed client for particular region
+        if region not in self._clients:
+            self._clients[region] = boto3.client(
+                "dynamodb",
+                region_name=region,
+                endpoint_url=self._endpoint_url,
+            )
+
+        return self._clients[region]
+
+    def _regions(self, table_name: str) -> list[str]:
+        # Return all AWS region(s) to be used for a specific table
+        out = None
+        for conf_key in ("table", "config_table"):
+            table_conf = self._conf.get(conf_key) or {}
+            if table_conf.get("name") == table_name:
+                out = table_conf.get("available_regions")
+                break
+
+        if not out:
+            LOG.warning(
+                "No config for %s, applying default regions", table_name
+            )
+            out = ["us-east-1"]
+
+        return out
+
+    def query(self, TableName: str, **kwargs) -> dict[str, Any]:
+        """Query items from a table.
+
+        This method has the same API as:
+        https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/dynamodb/client/query.html#DynamoDB.Client.query
+
+        ...but it will issue the query across *all* configured regions
+        for that table, in the order listed, until no error occurs.
+        """
+        output_error: Optional[BaseException] = None
+
+        for region in self._regions(TableName):
+            client = self._client(region)
+
+            # Should we fail over only in case of error or also in case of
+            # missing items?
+            #
+            # We choose "only in case of error" because:
+            #
+            # - if failing over in case of missing items, every 404 needs
+            #   to query every region
+            #
+            # - there is no known disaster scenario under which an item
+            #   would be missing from the primary but available from a
+            #   secondary. If items are accidentally deleted from the primary,
+            #   that would be expected to propagate to the secondaries within
+            #   a few seconds, so failover wouldn't help much.
+            #
+
+            try:
+                out = client.query(TableName=TableName, **kwargs)
+                if output_error:
+                    LOG.warning(
+                        (
+                            "Failover: query for table %s succeeded in region "
+                            "%s after prior errors"
+                        ),
+                        TableName,
+                        region,
+                    )
+                return out
+            except (
+                Exception  # pylint: disable=broad-exception-caught
+            ) as error:
+                LOG.warning(
+                    "Error querying table %s in region %s",
+                    TableName,
+                    region,
+                    exc_info=True,
+                )
+                # Chain exceptions across multiple regions so no error details
+                # are lost
+                error.__cause__ = output_error
+                output_error = error
+
+        # If we get here, every region failed.
+        assert output_error
+        raise output_error

--- a/tests/functions/test_query_helper.py
+++ b/tests/functions/test_query_helper.py
@@ -1,0 +1,62 @@
+import pytest
+
+from exodus_lambda.functions.db import QueryHelper
+
+
+class DynamoDbBrokenClient:
+    # A DynamoDb client for which all queries fail.
+
+    def __init__(self, service, region_name, *args, **kwargs):
+        assert service == "dynamodb"
+        self._region = region_name
+
+    def query(self, *args, **kwargs):
+        raise RuntimeError(f"error from {self._region}")
+
+
+def test_default_regions(caplog: pytest.LogCaptureFixture):
+    """QueryHelper applies reasonable default if region config is missing"""
+    db = QueryHelper({}, endpoint_url="https://aws.example.com/")
+
+    # It should succeed...
+    assert db._regions("my-table") == ["us-east-1"]
+
+    # But should also warn about this
+    assert (
+        "No config for my-table, applying default regions" in caplog.messages
+    )
+
+
+def test_all_regions_fail(monkeypatch: pytest.MonkeyPatch):
+    """Exceptions propagate correctly if queries fail in every configured region."""
+
+    db = QueryHelper(
+        {
+            "table": {
+                "name": "test",
+                "available_regions": ["region1", "region2", "region3"],
+            }
+        },
+        None,
+    )
+
+    monkeypatch.setattr("boto3.client", DynamoDbBrokenClient)
+
+    # It should raise an exception
+    with pytest.raises(BaseException) as excinfo:
+        db.query(TableName="test")
+
+    # Check the raised exception...
+    exc = excinfo.value
+
+    # The failure from every region should be represented
+    # via chained exceptions.
+    assert str(exc) == "error from region3"
+
+    assert exc.__cause__
+    assert str(exc.__cause__) == "error from region2"
+
+    assert exc.__cause__.__cause__
+    assert str(exc.__cause__.__cause__) == "error from region1"
+
+    assert exc.__cause__.__cause__.__cause__ is None


### PR DESCRIPTION
This commit reworks the handling of multiple regions for DynamoDB tables. We have long had the ability to configure multiple available regions, but the meaning of this region list has been changed.

Previously: this was a list of all regions expected to contain replicas, and the lambda would use this to decide if it could consult a table in its own local region for reduced latency.

Now: this is a list of all regions expected to contain replicas, *in the order in which they should be consulted regardless of the execution region*. Queries are tried on each region in order until one of them succeeds. In other words, we have a single-primary setup [1] where the first listed region is the primary, and all others are secondaries which are used only for failover to improve resilience.

The main reason for this change is the realization that we need strongly consistent reads. The prior setup has never been used in practice because we didn't deploy multi-region tables yet, but we are about to do so.

Also, the handling of multiple regions was buggy in some ways which have also been fixed. Those bugs were hidden until now since we only used a single region in practice.

- there were 'available_regions' in config for both the 'table' and 'config_table', yet the list for 'config_table' was simply ignored as no code ever accessed it.

- the 'available_regions' for table was also used to decide which region should be used for Secrets Manager. It doesn't make sense for those to be tied together since replication of DynamoDB and Secrets Manager are unrelated, and there are no plans to have multi-region SM. If available_regions had ever been set to anything other than ['us-east-1'], this would have caused crashes. The SM region can have its region configured independently.

[1] https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/bp-global-table-design.prescriptive-guidance.writemodes.html#bp-global-table-design.prescriptive-guidance.writemodes.single-primary