### PR TITLE
fakefront: fix bad Domain set on cookies in some cases

### DIFF
--- a/support/fakefront/lambdaio.py
+++ b/support/fakefront/lambdaio.py
@@ -22,8 +22,15 @@ class LambdaInput:
 
     def config(self, event_type: str):
         """Returns the config element of a cloudfront event."""
+
+        # Extract the client's idea of the hostname for use as the CF
+        # distribution name.
+        #
+        # In case of a host:port combination, only the host part should
+        # be used.
+        host = self._wsgi_environ["HTTP_HOST"].split(":")[0]
         return {
-            "distributionDomainName": self._wsgi_environ["SERVER_NAME"],
+            "distributionDomainName": host,
             "distributionId": "FAKEFRONT",
             "eventType": event_type,
             "requestId": self._request_id,


### PR DESCRIPTION
When simulating cloudfront events we used the WSGI SERVER_NAME variable as the cloudfront distribution hostname.

Problem: that variable seems to be the requested bind address passed to gunicorn, but that can be '0.0.0.0' to request binding to all addresses. That variable ends up being included as 'Domain=0.0.0.0' in responses to the /_/cookie endpoint, which causes the cookie never to match since 0.0.0.0 is not a valid domain.

Fix it by picking the hostname out of the HTTP Host header, which should always match the client's idea of the currently accessed host.

It seems like this has always been broken, but it was hidden since fakefront doesn't need/validate signed URLs or cookies. It was uncovered after a recent pipeline-test change which causes tests to more strictly parse returned cookies.