### PR TITLE
Revert "Upgrade exodus-cdn to Python3.11 runtime [RHELDST-18509]"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Set up Python 3.11
+    - name: Set up Python 3.9
       uses: actions/setup-python@v4
       with:
-        python-version: '3.11'
+        python-version: '3.9'
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/pip-compile.yml
+++ b/.github/workflows/pip-compile.yml
@@ -12,7 +12,7 @@ jobs:
      - name: Setup Python
        uses: actions/setup-python@v4
        with:
-         python-version: "3.11"
+         python-version: "3.9"
 
      - name: Install tox
        run: pip install tox

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,9 +3,9 @@ repos:
     rev: 23.9.1
     hooks:
     - id: black
-      language_version: python3.11
+      language_version: python3.9
 -   repo: https://github.com/pycqa/isort/
     rev: 5.12.0
     hooks:
     - id: isort
-      language_version: python3.11
+      language_version: python3.9

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.11
+python-3.9

--- a/setup.py
+++ b/setup.py
@@ -33,10 +33,9 @@ setup(
         "Development Status :: 4 - Beta",
         "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.11",
     ],
     install_requires=get_requirements(),
-    python_requires=">=3.11",
+    python_requires=">=3.9",
     project_urls={
         "Documentation": "https://release-engineering.github.io/exodus-lambda"
     },

--- a/support/fakefront/Containerfile
+++ b/support/fakefront/Containerfile
@@ -3,7 +3,7 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:8d43664c250c72d35af8498c
 COPY . /usr/local/src/exodus-lambda
 
 RUN \
-    microdnf -y install shadow-utils python3.11 python3.11-pip /usr/bin/openssl /usr/bin/envsubst \
+    microdnf -y install shadow-utils python39 /usr/bin/openssl /usr/bin/envsubst \
     && cd /usr/local/src/exodus-lambda \
     && pip3 install --require-hashes -r requirements-fakefront.txt \
     && pip3 install --editable . \

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py311, static, docs
+envlist = py39, static, docs
 
 [testenv]
 deps=
@@ -133,7 +133,7 @@ relative_files = true
 
 [testenv:pip-compile]
 deps = pip-tools
-basepython = python3.11
+basepython = python3.9
 skip_install = true
 skipsdist = true
 commands =


### PR DESCRIPTION
This reverts commit df7f84a4a731e426066ae362350180596ed17b41.