### PR TITLE
Implement missing URI decoding step [RHELDST-20564]

### DIFF
--- a/exodus_lambda/functions/origin_request.py
+++ b/exodus_lambda/functions/origin_request.py
@@ -3,6 +3,7 @@ import json
 import os
 import time
 import urllib
+import urllib.parse
 from datetime import datetime, timedelta, timezone
 
 import boto3
@@ -353,6 +354,8 @@ class OriginRequest(LambdaBase):
             "Incoming request value for origin_request",
             extra={"request": request},
         )
+
+        request["uri"] = urllib.parse.unquote(request["uri"])
 
         if request["uri"].startswith("/_/cookie/"):
             return self.handle_cookie_request(event)


### PR DESCRIPTION
URIs which have been percent-encoded need to be decoded prior to DynamoDB lookup. Lambda@Edge does not do this on our behalf.

This commit adds the missing decode step, which brings the overall behavior in line with other services including httpd and NetStorage.