### PR TITLE
Reuse policy,signature from cookie request querystring [RHELDST-18071]

### DIFF
--- a/exodus_lambda/functions/signer.py
+++ b/exodus_lambda/functions/signer.py
@@ -19,34 +19,52 @@ def cf_b64(data: bytes):
 
 
 class Signer:
-    def __init__(self, private_key_pem: str, key_id: str):
-        self.private_key = serialization.load_pem_private_key(
-            private_key_pem.encode("utf-8"),
-            password=None,
-            backend=default_backend(),
-        )
+    def __init__(self, private_key_pem: str = "", key_id: str = ""):
+        self.private_key_pem = private_key_pem
         self.key_id = key_id
-        self.cf_signer = CloudFrontSigner(self.key_id, self.rsa_sign)
+        self._private_key = None
+        self._cf_signer = None
+
+    @property
+    def private_key(self):
+        if self.private_key_pem and (self._private_key is None):
+            self._private_key = serialization.load_pem_private_key(
+                self.private_key_pem.encode("utf-8"),
+                password=None,
+                backend=default_backend(),
+            )
+        return self._private_key
+
+    @property
+    def cf_signer(self):
+        if self._cf_signer is None:
+            self._cf_signer = CloudFrontSigner(self.key_id, self.rsa_sign)
+        return self._cf_signer
 
     def rsa_sign(self, message):
         return self.private_key.sign(
             message, padding.PKCS1v15(), hashes.SHA1()  # nosec
         )
 
-    def cookies_for_policy(self, append, **kwargs):
-        policy = self.cf_signer.build_policy(**kwargs)
+    def cookies_for_policy(
+        self, policy: str = "", signature: str = "", append: str = "", **kwargs
+    ):
+        if not policy:
+            # If a policy wasn't provided we shouldn't trust the signature.
+            # Build policy and sign, overwriting the signature if provided.
+            LOG.debug("Building new policy for: %s", kwargs.get("resource"))
+            policy = self.cf_signer.build_policy(**kwargs)
 
-        LOG.debug("Signing policy: %s", policy)
+            LOG.debug("Signing policy: %s", policy)
+            policy_b = policy.encode("utf-8")
+            signature_b = self.cf_signer.rsa_signer(policy_b)
 
-        policy = policy.encode("utf-8")
-        signature = self.cf_signer.rsa_signer(policy)
-
-        policy_b64 = cf_b64(policy).decode("utf-8")
-        signature_b64 = cf_b64(signature).decode("utf-8")
+            policy = cf_b64(policy_b).decode("utf-8")
+            signature = cf_b64(signature_b).decode("utf-8")
 
         out = []
         out.append("CloudFront-Key-Pair-Id=%s%s" % (self.key_id, append))
-        out.append("CloudFront-Policy=%s%s" % (policy_b64, append))
-        out.append("CloudFront-Signature=%s%s" % (signature_b64, append))
+        out.append("CloudFront-Policy=%s%s" % (policy, append))
+        out.append("CloudFront-Signature=%s%s" % (signature, append))
 
         return out


### PR DESCRIPTION
When a client provides a policy and signature with a cookie request, reuse it when constructing a redirect response to avoid unecessarily loading the cookie key, building a policy, and generating a signature.