### PR TITLE
Fix trailing / redirect leaking alias info [RHELDST-21903]

### DIFF
--- a/exodus_lambda/functions/origin_request.py
+++ b/exodus_lambda/functions/origin_request.py
@@ -310,6 +310,7 @@ class OriginRequest(LambdaBase):
         )
 
         request["uri"] = unquote(request["uri"])
+        original_uri = request["uri"]
 
         if request["uri"].startswith("/_/cookie/"):
             return self.handle_cookie_request(event)
@@ -354,7 +355,7 @@ class OriginRequest(LambdaBase):
                             "status": "302",
                             "headers": {
                                 "location": [
-                                    {"value": uri + "/"},
+                                    {"value": original_uri + "/"},
                                 ],
                             },
                         }

--- a/tests/functions/test_origin_request.py
+++ b/tests/functions/test_origin_request.py
@@ -781,6 +781,15 @@ def test_origin_request_directly_request_autoindex_uri(
             "/content/dist/rhel/repo/x86_64/Packages/.__exodus_autoindex",
             "/content/dist/rhel/repo/x86_64/Packages/",
         ),
+        (
+            # Case where an alias is involved.
+            # The user requests a path on the src side of a /rhui/ alias:
+            "/content/dist/rhel8/rhui/repo/x86_64/Packages",
+            # The actual index object is stored on the dest side:
+            "/content/dist/rhel8/repo/x86_64/Packages/.__exodus_autoindex",
+            # The redirect works but retains the src side:
+            "/content/dist/rhel8/rhui/repo/x86_64/Packages/",
+        ),
     ],
 )
 @mock.patch("boto3.client")


### PR DESCRIPTION
In order for directory listings to work properly for users, if the user requests "/some/path", they will be redirected to the same path with a trailing slash added, i.e. "/some/path/".

Problem: the implemented logic was previously returning a path to the user *after* the resolution of rhui and releasever aliases. For example:

- user requested: /content/dist/rhel9/rhui/9/x86_64/supplementary/os
- redirected to:  /content/dist/rhel9/9.3/x86_64/supplementary/os/

The usage of aliases should not be leaked in this way. Fix it to work as desired, which is for example:

- user requested: /content/dist/rhel9/rhui/9/x86_64/supplementary/os
- redirected to:  /content/dist/rhel9/rhui/9/x86_64/supplementary/os/