### PR TITLE
Strip certain headers from S3 responses [RHELDST-22613]

### DIFF
--- a/docs/schemas/raw/lambda_config.yaml
+++ b/docs/schemas/raw/lambda_config.yaml
@@ -53,6 +53,17 @@ properties:
     required:
     - max_age
 
+  strip_headers:
+    type: array
+    description: >-
+      List of header prefixes to strip from responses.
+      Any headers starting with any of these strings will be removed from
+      S3 responses in the origin_response lambda.
+    items:
+      type: string
+      maxLength: 100
+      minLength: 1
+
   index_filename:
     type: string
     description: >-

--- a/exodus_lambda/functions/origin_response.py
+++ b/exodus_lambda/functions/origin_response.py
@@ -10,6 +10,24 @@ class OriginResponse(LambdaBase):
     def __init__(self, conf_file=CONF_FILE):
         super().__init__("origin-response", conf_file)
 
+    def strip_response_headers(self, response):
+        # Remove some headers which should not be in the response,
+        # according to 'strip_headers' config item.
+        prefixes = self.conf.get("strip_headers") or [
+            "x-amz-meta-",
+            "x-amz-replication-status",
+            "x-amz-server-side-encryption",
+            "x-amz-version-id",
+        ]
+        headers = response.get("headers") or {}
+        to_remove = [
+            key
+            for key in headers.keys()
+            if any([key.startswith(p) for p in prefixes])
+        ]
+        for key in to_remove:
+            del headers[key]
+
     def handler(self, event, context):
         # pylint: disable=unused-argument
 
@@ -45,6 +63,8 @@ class OriginResponse(LambdaBase):
 
         if original_uri:
             self.set_cache_control(original_uri, response)
+
+        self.strip_response_headers(response)
 
         self.logger.debug(
             "Completed response processing",


### PR DESCRIPTION
We were allowing all headers returned by S3 to propagate normally. It would be better to strip some of them.
These are considered to be internal implementation details and we'd rather not have clients come to depend on them, since that might make it difficult for us to change things later. For example: we don't want people to start extracting MD5 checksums from "x-amz-meta-exodus-migration-md5".

The set of headers to strip can be specified by a new 'strip_headers' config item, but there's a reasonable hardcoded default.