### PR TITLE
safety: ignore irrelevant Jinja CVE

### DIFF
--- a/.safety-policy.yml
+++ b/.safety-policy.yml
@@ -1,0 +1,15 @@
+security:
+  ignore-cvss-severity-below: 4
+  ignore-vulnerabilities:
+    70612:
+      # CVE-2019-8341, jinja2:
+      #
+      # In summary, the CVE says that it is unsafe to use untrusted
+      # user input as Jinja template sources as arbitrary code execution
+      # is possible. This should be obvious, so unsurprisingly Jinja
+      # maintainers and various third-parties reject/dispute the CVE,
+      # including Red Hat in https://bugzilla.redhat.com/show_bug.cgi?id=1677653
+      #
+      reason: >-
+        Not exploitable: user input is not used in any Jinja template sources
+  continue-on-vulnerability-error: False


### PR DESCRIPTION
safety started to complain about CVE-2019-8341 in jinja. The validity of the CVE is widely disputed, and in any case it is not exploitable here, so add it to the ignored list.