### PR TITLE
Fix double base64 encoding in config [RHELDST-25461]

### DIFF
--- a/exodus_lambda/functions/origin_request.py
+++ b/exodus_lambda/functions/origin_request.py
@@ -66,9 +66,8 @@ class OriginRequest(LambdaBase):
             )
             if query_result["Items"]:
                 item = query_result["Items"][0]
-                if item_encoded := item["config"].get("B"):
+                if item_bytes := item["config"].get("B"):
                     # new-style: config is compressed and stored as bytes
-                    item_bytes = b64decode(item_encoded)
                     item_json = gzip.decompress(item_bytes).decode()
                 else:
                     # old-style, config was stored as JSON string.

--- a/tests/functions/test_origin_request.py
+++ b/tests/functions/test_origin_request.py
@@ -1,7 +1,6 @@
 import gzip
 import json
 import logging
-from base64 import b64encode
 from urllib.parse import unquote, urlencode
 
 import mock
@@ -349,13 +348,14 @@ def test_origin_request_invalid_item(
 def test_origin_request_definitions(mocked_boto3_client, binary_config: bool):
     mocked_defs = mock_definitions()
     json_defs = json.dumps(mocked_defs)
+    config: dict[str, str | bytes] = {}
 
     if binary_config:
         # Config in the style exodus-gw writes from late 2024 onwards
-        config = {"B": b64encode(gzip.compress(json_defs.encode())).decode()}
+        config["B"] = gzip.compress(json_defs.encode())
     else:
         # Older-style config
-        config = {"S": json_defs}
+        config["S"] = json_defs
 
     mocked_boto3_client().query.return_value = {
         "Items": [


### PR DESCRIPTION
It was not correct to do a base64 decode here, because botocore already does that implicitly on both reads and writes of 'B' attributes on DynamoDB items. Drop the unnecessary decoding.

Note that the code here "worked" because the writing side in exodus-gw made the same mistake, ultimately ending up with items having two layers of base64 encoding. That will be fixed, but the reading side here needs to be fixed first.