### PR TITLE
Support "exclude_paths" in exodus-cdn [RHELDST-26014]

### DIFF
--- a/exodus_lambda/functions/origin_request.py
+++ b/exodus_lambda/functions/origin_request.py
@@ -103,11 +103,15 @@ class OriginRequest(LambdaBase):
             processed = []
 
             for alias in remaining:
-                exclusion_match = not ignore_exclusions and \
-                                  any([re.search(exclusion, uri) for exclusion
-                                       in alias.get("exclude_paths",[])])
-                if (uri.startswith(alias["src"] + "/") or uri == alias["src"]) \
-                        and not exclusion_match:
+                exclusion_match = not ignore_exclusions and any(
+                    [
+                        re.search(exclusion, uri)
+                        for exclusion in alias.get("exclude_paths", [])
+                    ]
+                )
+                if (
+                    uri.startswith(alias["src"] + "/") or uri == alias["src"]
+                ) and not exclusion_match:
                     uri = uri.replace(alias["src"], alias["dest"], 1)
                     processed.append(alias)
 
@@ -125,17 +129,20 @@ class OriginRequest(LambdaBase):
     def resolve_aliases(self, uri, ignore_exclusions=False):
         # aliases relating to origin, e.g. content/origin <=> origin
 
-        uri = self.uri_alias(uri, self.definitions.get("origin_alias"),
-                             ignore_exclusions)
+        uri = self.uri_alias(
+            uri, self.definitions.get("origin_alias"), ignore_exclusions
+        )
         # aliases relating to rhui; listing files are a special exemption
         # because they must be allowed to differ for rhui vs non-rhui.
         if not uri.endswith("/listing"):
-            uri = self.uri_alias(uri, self.definitions.get("rhui_alias"),
-                                 ignore_exclusions)
+            uri = self.uri_alias(
+                uri, self.definitions.get("rhui_alias"), ignore_exclusions
+            )
 
         # aliases relating to releasever; e.g. /content/dist/rhel8/8 <=> /content/dist/rhel8/8.5
-        uri = self.uri_alias(uri, self.definitions.get("releasever_alias"),
-                             ignore_exclusions)
+        uri = self.uri_alias(
+            uri, self.definitions.get("releasever_alias"), ignore_exclusions
+        )
 
         self.logger.debug("Resolved request URI: %s", uri)
 
@@ -377,8 +384,9 @@ class OriginRequest(LambdaBase):
             return self.handle_cookie_request(event)
 
         preferred_uri = self.resolve_aliases(request["uri"])
-        fallback_uri = self.resolve_aliases(request["uri"],
-                                            ignore_exclusions=True)
+        fallback_uri = self.resolve_aliases(
+            request["uri"], ignore_exclusions=True
+        )
         uris = [preferred_uri]
         # Some file keys might take a while to update to reflect URI alias exclusions.
         # Allowing the original behaviour as a fallback will avoid a flood of 404 errors
@@ -391,7 +399,9 @@ class OriginRequest(LambdaBase):
                 return listing_response
 
             table = self.conf["table"]["name"]
-            if out := self.handle_file_request(request, table, original_uri, uri):
+            if out := self.handle_file_request(
+                request, table, original_uri, uri
+            ):
                 return out
 
             self.logger.info("No item found for URI: %s", uri)

--- a/exodus_lambda/functions/origin_request.py
+++ b/exodus_lambda/functions/origin_request.py
@@ -3,6 +3,7 @@ import functools
 import gzip
 import json
 import os
+import re
 import time
 from base64 import b64decode
 from datetime import datetime, timedelta, timezone
@@ -87,7 +88,7 @@ class OriginRequest(LambdaBase):
 
         return out
 
-    def uri_alias(self, uri, aliases):
+    def uri_alias(self, uri, aliases, ignore_exclusions=False):
         # Resolve every alias between paths within the uri (e.g.
         # allow RHUI paths to be aliased to non-RHUI).
         #
@@ -102,7 +103,11 @@ class OriginRequest(LambdaBase):
             processed = []
 
             for alias in remaining:
-                if uri.startswith(alias["src"] + "/") or uri == alias["src"]:
+                exclusion_match = not ignore_exclusions and \
+                                  any([re.search(exclusion, uri) for exclusion
+                                       in alias.get("exclude_paths",[])])
+                if (uri.startswith(alias["src"] + "/") or uri == alias["src"]) \
+                        and not exclusion_match:
                     uri = uri.replace(alias["src"], alias["dest"], 1)
                     processed.append(alias)
 
@@ -117,17 +122,20 @@ class OriginRequest(LambdaBase):
 
         return uri
 
-    def resolve_aliases(self, uri):
+    def resolve_aliases(self, uri, ignore_exclusions=False):
         # aliases relating to origin, e.g. content/origin <=> origin
-        uri = self.uri_alias(uri, self.definitions.get("origin_alias"))
 
+        uri = self.uri_alias(uri, self.definitions.get("origin_alias"),
+                             ignore_exclusions)
         # aliases relating to rhui; listing files are a special exemption
         # because they must be allowed to differ for rhui vs non-rhui.
         if not uri.endswith("/listing"):
-            uri = self.uri_alias(uri, self.definitions.get("rhui_alias"))
+            uri = self.uri_alias(uri, self.definitions.get("rhui_alias"),
+                                 ignore_exclusions)
 
         # aliases relating to releasever; e.g. /content/dist/rhel8/8 <=> /content/dist/rhel8/8.5
-        uri = self.uri_alias(uri, self.definitions.get("releasever_alias"))
+        uri = self.uri_alias(uri, self.definitions.get("releasever_alias"),
+                             ignore_exclusions)
 
         self.logger.debug("Resolved request URI: %s", uri)
 
@@ -304,33 +312,8 @@ class OriginRequest(LambdaBase):
             valid = False
         return valid
 
-    def handler(self, event, context):
-        # pylint: disable=unused-argument
-
-        request = event["Records"][0]["cf"]["request"]
-
-        if not self.validate_request(request):
-            return {"status": "400", "statusDescription": "Bad Request"}
-
-        self.logger.debug(
-            "Incoming request value for origin_request",
-            extra={"request": request},
-        )
-
-        request["uri"] = unquote(request["uri"])
-        original_uri = request["uri"]
-
-        if request["uri"].startswith("/_/cookie/"):
-            return self.handle_cookie_request(event)
-
-        uri = self.resolve_aliases(request["uri"])
-
-        listing_response = self.handle_listing_request(uri)
-        if listing_response:
-            self.set_cache_control(uri, listing_response)
-            return listing_response
-
-        table = self.conf["table"]["name"]
+    def handle_file_request(self, request, table, original_uri, uri):
+        # Try find the db entry corresponding to the uri.
 
         # Do not permit clients to explicitly request an index file
         if not uri.endswith("/" + self.index):
@@ -374,7 +357,44 @@ class OriginRequest(LambdaBase):
                         return response
 
                     return out
-        self.logger.info("No item found for URI: %s", uri)
+
+    def handler(self, event, context):
+        # pylint: disable=unused-argument
+        request = event["Records"][0]["cf"]["request"]
+
+        if not self.validate_request(request):
+            return {"status": "400", "statusDescription": "Bad Request"}
+
+        self.logger.debug(
+            "Incoming request value for origin_request",
+            extra={"request": request},
+        )
+
+        request["uri"] = unquote(request["uri"])
+        original_uri = request["uri"]
+
+        if request["uri"].startswith("/_/cookie/"):
+            return self.handle_cookie_request(event)
+
+        preferred_uri = self.resolve_aliases(request["uri"])
+        fallback_uri = self.resolve_aliases(request["uri"],
+                                            ignore_exclusions=True)
+        uris = [preferred_uri]
+        # Some file keys might take a while to update to reflect URI alias exclusions.
+        # Allowing the original behaviour as a fallback will avoid a flood of 404 errors
+        if preferred_uri != fallback_uri:
+            uris.append(fallback_uri)
+
+        for uri in uris:
+            if listing_response := self.handle_listing_request(uri):
+                self.set_cache_control(uri, listing_response)
+                return listing_response
+
+            table = self.conf["table"]["name"]
+            if out := self.handle_file_request(request, table, original_uri, uri):
+                return out
+
+            self.logger.info("No item found for URI: %s", uri)
         return {"status": "404", "statusDescription": "Not Found"}
 
 

--- a/tests/functions/test_alias.py
+++ b/tests/functions/test_alias.py
@@ -1,5 +1,6 @@
 # More in depth tests for alias resolution.
 from collections import namedtuple
+
 import pytest
 
 from exodus_lambda.functions.origin_request import OriginRequest
@@ -53,69 +54,101 @@ def test_alias_equal():
     "uri, expected_uri, ignore_exclusions, aliases",
     [
         (
-                "/origin/path/dir/filename.ext",
-                "/origin/path/dir/filename.ext",
-                False,
-                [{"src": "/origin/path", "dest": "/alias",
-                  "exclude_paths": ["/dir/"]}],
+            "/origin/path/dir/filename.ext",
+            "/origin/path/dir/filename.ext",
+            False,
+            [
+                {
+                    "src": "/origin/path",
+                    "dest": "/alias",
+                    "exclude_paths": ["/dir/"],
+                }
+            ],
         ),
         (
-                "/origin/path/dir/filename.ext",
-                "/alias/dir/filename.ext",
-                False,
-                [{"src": "/origin/path", "dest": "/alias",
-                  "exclude_paths": ["/banana/"]}],
+            "/origin/path/dir/filename.ext",
+            "/alias/dir/filename.ext",
+            False,
+            [
+                {
+                    "src": "/origin/path",
+                    "dest": "/alias",
+                    "exclude_paths": ["/banana/"],
+                }
+            ],
         ),
         (
-                "/origin/path/c/dir/filename.ext",
-                "/second/step/c/dir/filename.ext",
-                False,
-                [
-                    {"src": "/origin/path", "dest": "/first/step", "exclude_paths": ["/a/"]},
-                    {"src": "/first", "dest": "/second", "exclude_paths": ["/b/"]},
-                    {"src": "/second", "dest": "/third", "exclude_paths": ["/c/"]}
-                ],
+            "/origin/path/c/dir/filename.ext",
+            "/second/step/c/dir/filename.ext",
+            False,
+            [
+                {
+                    "src": "/origin/path",
+                    "dest": "/first/step",
+                    "exclude_paths": ["/a/"],
+                },
+                {"src": "/first", "dest": "/second", "exclude_paths": ["/b/"]},
+                {"src": "/second", "dest": "/third", "exclude_paths": ["/c/"]},
+            ],
         ),
         (
-                "/origin/path/rhel7/dir/filename.ext",
-                "/aliased/path/rhel7/dir/filename.ext",
-                False,
-                [
-                    {"src": "/origin", "dest": "/aliased",
-                     "exclude_paths": ["/rhel[89]/"]},
-                ],
+            "/origin/path/rhel7/dir/filename.ext",
+            "/aliased/path/rhel7/dir/filename.ext",
+            False,
+            [
+                {
+                    "src": "/origin",
+                    "dest": "/aliased",
+                    "exclude_paths": ["/rhel[89]/"],
+                },
+            ],
         ),
         (
-                "/origin/path/rhel9/dir/filename.ext",
-                "/origin/path/rhel9/dir/filename.ext",
-                False,
-                [
-                    {"src": "/origin", "dest": "/aliased",
-                     "exclude_paths": ["/rhel[89]/"]},
-                ],
+            "/origin/path/rhel9/dir/filename.ext",
+            "/origin/path/rhel9/dir/filename.ext",
+            False,
+            [
+                {
+                    "src": "/origin",
+                    "dest": "/aliased",
+                    "exclude_paths": ["/rhel[89]/"],
+                },
+            ],
         ),
         (
-                "/origin/path/rhel9/dir/filename.ext",
-                "/aliased/path/rhel9/dir/filename.ext",
-                True,
-                [
-                    {"src": "/origin", "dest": "/aliased",
-                     "exclude_paths": ["/rhel9/"]},
-                ],
+            "/origin/path/rhel9/dir/filename.ext",
+            "/aliased/path/rhel9/dir/filename.ext",
+            True,
+            [
+                {
+                    "src": "/origin",
+                    "dest": "/aliased",
+                    "exclude_paths": ["/rhel9/"],
+                },
+            ],
         ),
-(
-                "/origin/path/rhel9/dir/filename.ext",
-                "/aliased/path/rhel9/dir/filename.ext",
-                True,
-                [
-                    {"src": "/origin", "dest": "/aliased",
-                     "exclude_paths": ["/rhel7/"]},
-                ],
+        (
+            "/origin/path/rhel9/dir/filename.ext",
+            "/aliased/path/rhel9/dir/filename.ext",
+            True,
+            [
+                {
+                    "src": "/origin",
+                    "dest": "/aliased",
+                    "exclude_paths": ["/rhel7/"],
+                },
+            ],
         ),
     ],
-    ids=["excluded", "not excluded", "multilevel", "regex not excluded",
-         "regex excluded", "exclusion ignored matching",
-         "exclusion ignored no match"],
+    ids=[
+        "excluded",
+        "not excluded",
+        "multilevel",
+        "regex not excluded",
+        "regex excluded",
+        "exclusion ignored matching",
+        "exclusion ignored no match",
+    ],
 )
 def test_alias_exclusions(uri, expected_uri, ignore_exclusions, aliases):
     """Paths exactly matching an alias can be resolved."""

--- a/tests/functions/test_alias.py
+++ b/tests/functions/test_alias.py
@@ -1,5 +1,6 @@
 # More in depth tests for alias resolution.
 from collections import namedtuple
+import pytest
 
 from exodus_lambda.functions.origin_request import OriginRequest
 
@@ -7,7 +8,7 @@ from ..test_utils.utils import generate_test_config
 
 TEST_CONF = generate_test_config()
 
-Alias = namedtuple("Alias", ["src", "dest"])
+Alias = namedtuple("Alias", ["src", "dest", "exclude_paths"])
 
 
 def test_alias_single():
@@ -46,3 +47,79 @@ def test_alias_equal():
     aliases = [{"src": "/foo/bar", "dest": "/quux"}]
 
     assert req.uri_alias("/foo/bar", aliases) == "/quux"
+
+
+@pytest.mark.parametrize(
+    "uri, expected_uri, ignore_exclusions, aliases",
+    [
+        (
+                "/origin/path/dir/filename.ext",
+                "/origin/path/dir/filename.ext",
+                False,
+                [{"src": "/origin/path", "dest": "/alias",
+                  "exclude_paths": ["/dir/"]}],
+        ),
+        (
+                "/origin/path/dir/filename.ext",
+                "/alias/dir/filename.ext",
+                False,
+                [{"src": "/origin/path", "dest": "/alias",
+                  "exclude_paths": ["/banana/"]}],
+        ),
+        (
+                "/origin/path/c/dir/filename.ext",
+                "/second/step/c/dir/filename.ext",
+                False,
+                [
+                    {"src": "/origin/path", "dest": "/first/step", "exclude_paths": ["/a/"]},
+                    {"src": "/first", "dest": "/second", "exclude_paths": ["/b/"]},
+                    {"src": "/second", "dest": "/third", "exclude_paths": ["/c/"]}
+                ],
+        ),
+        (
+                "/origin/path/rhel7/dir/filename.ext",
+                "/aliased/path/rhel7/dir/filename.ext",
+                False,
+                [
+                    {"src": "/origin", "dest": "/aliased",
+                     "exclude_paths": ["/rhel[89]/"]},
+                ],
+        ),
+        (
+                "/origin/path/rhel9/dir/filename.ext",
+                "/origin/path/rhel9/dir/filename.ext",
+                False,
+                [
+                    {"src": "/origin", "dest": "/aliased",
+                     "exclude_paths": ["/rhel[89]/"]},
+                ],
+        ),
+        (
+                "/origin/path/rhel9/dir/filename.ext",
+                "/aliased/path/rhel9/dir/filename.ext",
+                True,
+                [
+                    {"src": "/origin", "dest": "/aliased",
+                     "exclude_paths": ["/rhel9/"]},
+                ],
+        ),
+(
+                "/origin/path/rhel9/dir/filename.ext",
+                "/aliased/path/rhel9/dir/filename.ext",
+                True,
+                [
+                    {"src": "/origin", "dest": "/aliased",
+                     "exclude_paths": ["/rhel7/"]},
+                ],
+        ),
+    ],
+    ids=["excluded", "not excluded", "multilevel", "regex not excluded",
+         "regex excluded", "exclusion ignored matching",
+         "exclusion ignored no match"],
+)
+def test_alias_exclusions(uri, expected_uri, ignore_exclusions, aliases):
+    """Paths exactly matching an alias can be resolved."""
+
+    req = OriginRequest(conf_file=TEST_CONF)
+
+    assert req.uri_alias(uri, aliases, ignore_exclusions) == expected_uri

--- a/tests/functions/test_origin_request.py
+++ b/tests/functions/test_origin_request.py
@@ -492,20 +492,25 @@ def test_origin_request_listing_typical(mocked_cache, caplog):
         },
     }
 
+
 @mock.patch("boto3.client")
 @mock.patch("exodus_lambda.functions.origin_request.cachetools")
-def test_origin_request_listing_fallback(mocked_cache, mocked_boto3_client, caplog):
+def test_origin_request_listing_fallback(
+    mocked_cache, mocked_boto3_client, caplog
+):
 
     req_uri = "/content/dist/rhel/myOwnRHEL/listing"
     real_uri = "/content/dist/rhel/extraSpecialRHEL/listing"
     definitions = mock_definitions()
-    definitions["listing"]["/content/dist/rhel/extraSpecialRHEL"]\
-        = {"var": "basearch", "values": ["x86_64"]}
+    definitions["listing"]["/content/dist/rhel/extraSpecialRHEL"] = {
+        "var": "basearch",
+        "values": ["x86_64"],
+    }
     test_alias = {
-            "src": "/content/dist/rhel/myOwnRHEL",
-            "dest": "/content/dist/rhel/extraSpecialRHEL",
-            "exclude_paths": ["listing"]
-        }
+        "src": "/content/dist/rhel/myOwnRHEL",
+        "dest": "/content/dist/rhel/extraSpecialRHEL",
+        "exclude_paths": ["listing"],
+    }
     definitions["releasever_alias"].append(test_alias)
     mocked_cache.TTLCache.return_value = {"exodus-config": definitions}
 
@@ -534,6 +539,7 @@ def test_origin_request_listing_fallback(mocked_cache, mocked_boto3_client, capl
             ],
         },
     }
+
 
 @mock.patch("boto3.client")
 @mock.patch("exodus_lambda.functions.origin_request.cachetools")
@@ -940,18 +946,25 @@ def test_fallback_uri(
                     "object_key": {"S": "e4a3f2sum"},
                 }
             ]
-        }
+        },
     ]
     expected_boto_calls = [
-        mock.call(TableName='test-table', Limit=1, ConsistentRead=True,
-          ScanIndexForward=False,
-          KeyConditionExpression='web_uri = :u and from_date <= :d',
-          ExpressionAttributeValues={
-              ':u': {'S': uri},
-              ':d': {'S': '2020-02-17T15:38:05.864+00:00'}}) for uri in
-                      ["/content/dist/rhel8/8/files/deletion.iso",
-                       "/content/dist/rhel8/8/files/deletion.iso/.__exodus_autoindex",
-                       "/content/dist/rhel8/8.5/files/deletion.iso"]
+        mock.call(
+            TableName="test-table",
+            Limit=1,
+            ConsistentRead=True,
+            ScanIndexForward=False,
+            KeyConditionExpression="web_uri = :u and from_date <= :d",
+            ExpressionAttributeValues={
+                ":u": {"S": uri},
+                ":d": {"S": "2020-02-17T15:38:05.864+00:00"},
+            },
+        )
+        for uri in [
+            "/content/dist/rhel8/8/files/deletion.iso",
+            "/content/dist/rhel8/8/files/deletion.iso/.__exodus_autoindex",
+            "/content/dist/rhel8/8.5/files/deletion.iso",
+        ]
     ]
     event = {"Records": [{"cf": {"request": {"uri": req_uri, "headers": {}}}}]}
 

--- a/tests/functions/test_origin_request.py
+++ b/tests/functions/test_origin_request.py
@@ -492,6 +492,48 @@ def test_origin_request_listing_typical(mocked_cache, caplog):
         },
     }
 
+@mock.patch("boto3.client")
+@mock.patch("exodus_lambda.functions.origin_request.cachetools")
+def test_origin_request_listing_fallback(mocked_cache, mocked_boto3_client, caplog):
+
+    req_uri = "/content/dist/rhel/myOwnRHEL/listing"
+    real_uri = "/content/dist/rhel/extraSpecialRHEL/listing"
+    definitions = mock_definitions()
+    definitions["listing"]["/content/dist/rhel/extraSpecialRHEL"]\
+        = {"var": "basearch", "values": ["x86_64"]}
+    test_alias = {
+            "src": "/content/dist/rhel/myOwnRHEL",
+            "dest": "/content/dist/rhel/extraSpecialRHEL",
+            "exclude_paths": ["listing"]
+        }
+    definitions["releasever_alias"].append(test_alias)
+    mocked_cache.TTLCache.return_value = {"exodus-config": definitions}
+
+    event = {"Records": [{"cf": {"request": {"uri": req_uri, "headers": {}}}}]}
+
+    # No file in DB for handle_file_request to find.
+    mocked_boto3_client().query.side_effect = [
+        {"Items": []},  # req_uri
+        {"Items": []},  # req_uri index page
+    ]
+
+    request = OriginRequest(conf_file=TEST_CONF).handler(event, context=None)
+
+    assert f"Handling listing request: {req_uri}" in caplog.text
+    assert f"No item found for URI: {req_uri}" in caplog.text
+    assert f"Handling listing request: {real_uri}" in caplog.text
+    # It should successfully generate appropriate listing response.
+    assert request == {
+        "body": "x86_64\n",
+        "status": "200",
+        "statusDescription": "OK",
+        "headers": {
+            "content-type": [{"key": "Content-Type", "value": "text/plain"}],
+            "cache-control": [
+                {"key": "Cache-Control", "value": "max-age=600"}
+            ],
+        },
+    }
 
 @mock.patch("boto3.client")
 @mock.patch("exodus_lambda.functions.origin_request.cachetools")
@@ -868,3 +910,68 @@ def test_origin_request_autoindex(
         }
 
     assert response == expected_response
+
+
+@mock.patch("boto3.client")
+@mock.patch("exodus_lambda.functions.origin_request.cachetools")
+@mock.patch("exodus_lambda.functions.origin_request.datetime")
+def test_fallback_uri(
+    mocked_datetime,
+    mocked_cache,
+    mocked_boto3_client,
+    caplog,
+):
+    # After the introduction of exclusion_paths, some files are still stored
+    # under the aliased uri. We try the "correct" uri and fallback to the older aliased uri
+
+    req_uri = "/content/dist/rhel8/8/files/deletion.iso"
+    real_uri = "/content/dist/rhel8/8.5/files/deletion.iso"
+    mocked_datetime.now().isoformat.return_value = MOCKED_DT
+    mocked_cache.TTLCache.return_value = {"exodus-config": mock_definitions()}
+
+    mocked_boto3_client().query.side_effect = [
+        {"Items": []},  # req_uri
+        {"Items": []},  # req_uri index page
+        {
+            "Items": [
+                {
+                    "web_uri": {"S": real_uri},
+                    "from_date": {"S": "2020-02-17T00:00:00.000+00:00"},
+                    "object_key": {"S": "e4a3f2sum"},
+                }
+            ]
+        }
+    ]
+    expected_boto_calls = [
+        mock.call(TableName='test-table', Limit=1, ConsistentRead=True,
+          ScanIndexForward=False,
+          KeyConditionExpression='web_uri = :u and from_date <= :d',
+          ExpressionAttributeValues={
+              ':u': {'S': uri},
+              ':d': {'S': '2020-02-17T15:38:05.864+00:00'}}) for uri in
+                      ["/content/dist/rhel8/8/files/deletion.iso",
+                       "/content/dist/rhel8/8/files/deletion.iso/.__exodus_autoindex",
+                       "/content/dist/rhel8/8.5/files/deletion.iso"]
+    ]
+    event = {"Records": [{"cf": {"request": {"uri": req_uri, "headers": {}}}}]}
+
+    with caplog.at_level(logging.DEBUG):
+        request = OriginRequest(
+            conf_file=TEST_CONF,
+        ).handler(event, context=None)
+
+    assert f"Item found for URI: {real_uri}" in caplog.text
+    assert f"No item found for URI: {req_uri}"
+
+    mocked_boto3_client().query.assert_has_calls(expected_boto_calls)
+    assert request == {
+        "uri": "/e4a3f2sum",
+        "querystring": urlencode(
+            {"response-content-type": "application/octet-stream"}
+        ),
+        "headers": {
+            "exodus-original-uri": [
+                {"key": "exodus-original-uri", "value": req_uri}
+            ]
+        },
+    }

--- a/tests/test_data/exodus-config.json
+++ b/tests/test_data/exodus-config.json
@@ -6,7 +6,8 @@
         },
         {
             "src": "/origin/rpm",
-            "dest": "/origin/rpms"
+            "dest": "/origin/rpms",
+            "exclude_paths": []
         }
     ],
     "rhui_alias": [
@@ -92,19 +93,23 @@
         },
         {
             "src": "/content/els/rhel/rhui",
-            "dest": "/content/els/rhel"
+            "dest": "/content/els/rhel",
+            "exclude_paths": []
         },
         {
             "src": "/content/eus/rhel8/rhui",
-            "dest": "/content/eus/rhel8"
+            "dest": "/content/eus/rhel8",
+            "exclude_paths": []
         },
         {
             "src": "/content/eus/rhel/rhui",
-            "dest": "/content/eus/rhel"
+            "dest": "/content/eus/rhel",
+            "exclude_paths": []
         },
         {
             "src": "/content/rc/rhel/rhui",
-            "dest": "/content/rc/rhel"
+            "dest": "/content/rc/rhel",
+            "exclude_paths": []
         }
     ],
     "releasever_alias": [
@@ -134,27 +139,33 @@
         },
         {
             "src": "/content/dist/rhel/power/7/7Server",
-            "dest": "/content/dist/rhel/power/7/7.9"
+            "dest": "/content/dist/rhel/power/7/7.9",
+            "exclude_paths": []
         },
         {
             "src": "/content/dist/rhel/server/7/7Server",
-            "dest": "/content/dist/rhel/server/7/7.9"
+            "dest": "/content/dist/rhel/server/7/7.9",
+            "exclude_paths": []
         },
         {
             "src": "/content/dist/rhel/system-z/7/7Server",
-            "dest": "/content/dist/rhel/system-z/7/7.9"
+            "dest": "/content/dist/rhel/system-z/7/7.9",
+            "exclude_paths": []
         },
         {
             "src": "/content/dist/rhel/workstation/7/7Workstation",
-            "dest": "/content/dist/rhel/workstation/7/7.9"
+            "dest": "/content/dist/rhel/workstation/7/7.9",
+            "exclude_paths": ["/files/", "/images/", "/iso/"]
         },
         {
             "src": "/content/dist/rhel8/8",
-            "dest": "/content/dist/rhel8/8.5"
+            "dest": "/content/dist/rhel8/8.5",
+            "exclude_paths": ["/files/", "/images/", "/iso/"]
         },
         {
             "src": "/content/dist/rhel9/9",
-            "dest": "/content/dist/rhel9/9.0"
+            "dest": "/content/dist/rhel9/9.0",
+            "exclude_paths": ["/files/", "/images/", "/iso/"]
         }
     ],
     "listing": {


### PR DESCRIPTION
Certain paths on our NetStorage fs have no symlinks/aliases, and teams/tools that make use of these paths expect similar behaviour from exodus.

This change introduces "exclude_paths" to exclude alias generation for certain paths, so we can replicate NetStorage behaviour. We maintain the previous behaviour as a "fallback" in case the item key hasn't or can't be updated in the database. This will prevent items from disappearing once we cut over.