### PR TITLE
Fixup: remove mentions of /images/  [RHELDST-26015]

### DIFF
--- a/tests/test_data/exodus-config.json
+++ b/tests/test_data/exodus-config.json
@@ -155,17 +155,17 @@
         {
             "src": "/content/dist/rhel/workstation/7/7Workstation",
             "dest": "/content/dist/rhel/workstation/7/7.9",
-            "exclude_paths": ["/files/", "/images/", "/iso/"]
+            "exclude_paths": ["/files/", "/iso/"]
         },
         {
             "src": "/content/dist/rhel8/8",
             "dest": "/content/dist/rhel8/8.5",
-            "exclude_paths": ["/files/", "/images/", "/iso/"]
+            "exclude_paths": ["/files/", "/iso/"]
         },
         {
             "src": "/content/dist/rhel9/9",
             "dest": "/content/dist/rhel9/9.0",
-            "exclude_paths": ["/files/", "/images/", "/iso/"]
+            "exclude_paths": ["/files/", "/iso/"]
         }
     ],
     "listing": {


### PR DESCRIPTION
It was noted that including the /images/ path can cause issues with kickstart repos as the path can occur within repos. This complication makes the path less appropriate for blanket exclusions. This change removes mentions of /images/ from tests to prevent later confusion.