### PR TITLE
Add mirror_reads property to schema [RHELDST-28332]

### DIFF
--- a/docs/schemas/raw/lambda_config.yaml
+++ b/docs/schemas/raw/lambda_config.yaml
@@ -39,6 +39,18 @@ properties:
     maximum: 10000
     minimum: 0
 
+  mirror_reads:
+    type: string
+    description: >-
+      Whether to enable (true) or disable (false) the mirrored reads feature. When
+      exodus-cdn looks up content to be served for a path having a $releasever alias
+      in effect, if mirror_reads is enabled (true), the exodus-cdn will attempt to
+      look up content on both sides of the alias; if mirror_reads is disabled (false),
+      the exodus-cdn will only attempt to look up content on the destination side of the
+      alias.
+    maxLength: 5
+    minLength: 1
+
   headers:
     type: object
     properties:


### PR DESCRIPTION
The previous commit which introduced the mirror reads feature (including the mirror_reads config property) neglected to add the mirror_reads property to the exodus-lambda config schema.