### PR TITLE
Update renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,9 +1,13 @@
 {
-  "enabled": true,
   "enabledManagers": ["dockerfile", "github-actions"],
   "dockerfile": {
     "fileMatch": [".*Containerfile$"]
   },
-  "automerge": true,
-  "stabilityDays": 3
+  "minimumReleaseAge": "3 days",
+  "packageRules": [
+    {
+      "matchDepTypes": ["uses-with"],
+      "enabled": false
+    }
+  ]
 }


### PR DESCRIPTION
- remove enabled and automerge, as values were default
- replace stabilityDays with new minimumReleaseAge
- add packageRules with config to prevent python-version upgrades