### PR TITLE
Lock marshmallow, update requirements

### DIFF
--- a/requirements-fakefront.txt
+++ b/requirements-fakefront.txt
@@ -6,21 +6,21 @@
 #
 --only-binary :all:
 
-boto3==1.37.33 \
-    --hash=sha256:7b1b1bc69762975824e5a5d570880abebf634f7594f88b3dc175e8800f35be1a
-    # via -r /home/runner/work/exodus-lambda/exodus-lambda/requirements.in
-botocore==1.37.33 \
-    --hash=sha256:4a167dfecae51e9140de24067de1c339acde5ade3dad524a4600ac2c72055e23
+boto3==1.38.2 \
+    --hash=sha256:ef3237b169cd906a44a32c03b3229833d923c9e9733355b329ded2151f91ec0b
+    # via -r requirements.in
+botocore==1.38.2 \
+    --hash=sha256:5d9cffedb1c759a058b43793d16647ed44ec87072f98a1bd6cd673ac0ae6b81d
     # via
-    #   -r /home/runner/work/exodus-lambda/exodus-lambda/requirements.in
+    #   -r requirements.in
     #   boto3
     #   s3transfer
 cachetools==5.5.2 \
     --hash=sha256:d26a22bcc62eb95c3beabd9f1ee5e820d3d2704fe2967cbe350e20c8ffcd3f0a
-    # via -r /home/runner/work/exodus-lambda/exodus-lambda/requirements.in
+    # via -r requirements.in
 cdn-definitions==3.3.0 \
     --hash=sha256:e614d54ef65f1873eed2f7292e3b96b8a6eade967cdca1f8fe2fc13eb66cea1a
-    # via -r /home/runner/work/exodus-lambda/exodus-lambda/requirements.in
+    # via -r requirements.in
 certifi==2025.1.31 \
     --hash=sha256:ca78db4565a652026a4db2bcdf68f2fb589ea80d0be70e03929ed730746b84fe
     # via requests
@@ -220,10 +220,10 @@ cryptography==44.0.2 \
     --hash=sha256:d1c3572526997b36f245a96a2b1713bf79ce99b271bbcf084beb6b9b075f29ea \
     --hash=sha256:efcfe97d1b3c79e486554efddeb8f6f53a4cdd4cf6086642784fa31fc384e1d7 \
     --hash=sha256:f514ef4cd14bb6fb484b4a60203e912cfcb64f2ab139e88c2274511514bf7308
-    # via -r /home/runner/work/exodus-lambda/exodus-lambda/requirements.in
+    # via -r requirements.in
 docutils==0.21.2 \
     --hash=sha256:dafca5b9e384f0e419294eb4d2ff9fa826435bf15f15b7bd45723e8ad76811b2
-    # via -r /home/runner/work/exodus-lambda/exodus-lambda/requirements.in
+    # via -r requirements.in
 frozendict==2.4.6 \
     --hash=sha256:02331541611f3897f260900a1815b63389654951126e6e65545e529b63c08361 \
     --hash=sha256:0aaa11e7c472150efe65adbcd6c17ac0f586896096ab3963775e1c5c58ac0098 \
@@ -278,8 +278,8 @@ jmespath==1.0.1 \
     # via
     #   boto3
     #   botocore
-packaging==24.2 \
-    --hash=sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759
+packaging==25.0 \
+    --hash=sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484
     # via gunicorn
 pycparser==2.22 \
     --hash=sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc
@@ -341,15 +341,15 @@ pyyaml==6.0.2 \
     --hash=sha256:f753120cb8181e736c57ef7636e83f31b9c0d1722c516f7e86cf15b7aa57ff12 \
     --hash=sha256:ff3824dc5261f50c9b0dfb3be22b4567a6f938ccce4587b38952d85fd9e9afe4
     # via
-    #   -r /home/runner/work/exodus-lambda/exodus-lambda/requirements.in
+    #   -r requirements.in
     #   cdn-definitions
 requests==2.32.3 \
     --hash=sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6
     # via
-    #   -r /home/runner/work/exodus-lambda/exodus-lambda/requirements.in
+    #   -r requirements.in
     #   cdn-definitions
-s3transfer==0.11.4 \
-    --hash=sha256:ac265fa68318763a03bf2dc4f39d5cbd6a9e178d81cc9483ad27da33637e320d
+s3transfer==0.12.0 \
+    --hash=sha256:35b314d7d82865756edab59f7baebc6b477189e6ab4c53050e28c1de4d9cce18
     # via boto3
 six==1.17.0 \
     --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,11 +6,11 @@
 #
 --only-binary :all:
 
-boto3==1.37.33 \
-    --hash=sha256:7b1b1bc69762975824e5a5d570880abebf634f7594f88b3dc175e8800f35be1a
+boto3==1.38.2 \
+    --hash=sha256:ef3237b169cd906a44a32c03b3229833d923c9e9733355b329ded2151f91ec0b
     # via -r requirements.in
-botocore==1.37.33 \
-    --hash=sha256:4a167dfecae51e9140de24067de1c339acde5ade3dad524a4600ac2c72055e23
+botocore==1.38.2 \
+    --hash=sha256:5d9cffedb1c759a058b43793d16647ed44ec87072f98a1bd6cd673ac0ae6b81d
     # via
     #   -r requirements.in
     #   boto3
@@ -342,8 +342,8 @@ requests==2.32.3 \
     # via
     #   -r requirements.in
     #   cdn-definitions
-s3transfer==0.11.4 \
-    --hash=sha256:ac265fa68318763a03bf2dc4f39d5cbd6a9e178d81cc9483ad27da33637e320d
+s3transfer==0.12.0 \
+    --hash=sha256:35b314d7d82865756edab59f7baebc6b477189e6ab4c53050e28c1de4d9cce18
     # via boto3
 six==1.17.0 \
     --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -9,3 +9,5 @@ importlib-metadata
 bandit
 safety
 freezegun
+# marshmallow (dependency of safety) version 4.0 introduces breaking changes
+marshmallow<4

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -9,6 +9,9 @@
 annotated-types==0.7.0 \
     --hash=sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53
     # via pydantic
+anyio==4.9.0 \
+    --hash=sha256:9f76d541cad6e36af7beb62e978876f3b41e3e04f2c1fbf0884604c0a9c4d93c
+    # via httpx
 astroid==3.3.9 \
     --hash=sha256:d05bfd0acba96a7bd43e222828b7d9bc1e138aaeb0649707908d3702a9831248
     # via pylint
@@ -18,31 +21,27 @@ authlib==1.5.2 \
 bandit==1.8.3 \
     --hash=sha256:28f04dc0d258e1dd0f99dee8eefa13d1cb5e3fde1a5ab0c523971f97b289bcd8
     # via -r test-requirements.in
-boto3==1.37.33 \
-    --hash=sha256:7b1b1bc69762975824e5a5d570880abebf634f7594f88b3dc175e8800f35be1a
+boto3==1.38.2 \
+    --hash=sha256:ef3237b169cd906a44a32c03b3229833d923c9e9733355b329ded2151f91ec0b
+    # via -r requirements.in
+botocore==1.38.2 \
+    --hash=sha256:5d9cffedb1c759a058b43793d16647ed44ec87072f98a1bd6cd673ac0ae6b81d
     # via
-    #   -r /home/runner/work/exodus-lambda/exodus-lambda/requirements.in
-    #   -r requirements.in
-botocore==1.37.33 \
-    --hash=sha256:4a167dfecae51e9140de24067de1c339acde5ade3dad524a4600ac2c72055e23
-    # via
-    #   -r /home/runner/work/exodus-lambda/exodus-lambda/requirements.in
     #   -r requirements.in
     #   boto3
     #   s3transfer
 cachetools==5.5.2 \
     --hash=sha256:d26a22bcc62eb95c3beabd9f1ee5e820d3d2704fe2967cbe350e20c8ffcd3f0a
-    # via
-    #   -r /home/runner/work/exodus-lambda/exodus-lambda/requirements.in
-    #   -r requirements.in
+    # via -r requirements.in
 cdn-definitions==3.3.0 \
     --hash=sha256:e614d54ef65f1873eed2f7292e3b96b8a6eade967cdca1f8fe2fc13eb66cea1a
-    # via
-    #   -r /home/runner/work/exodus-lambda/exodus-lambda/requirements.in
-    #   -r requirements.in
+    # via -r requirements.in
 certifi==2025.1.31 \
     --hash=sha256:ca78db4565a652026a4db2bcdf68f2fb589ea80d0be70e03929ed730746b84fe
-    # via requests
+    # via
+    #   httpcore
+    #   httpx
+    #   requests
 cffi==1.17.1 \
     --hash=sha256:045d61c734659cc045141be4bae381a41d89b741f795af1dd018bfb532fd0df8 \
     --hash=sha256:0984a4925a435b1da406122d4d7968dd861c1385afe3b45ba82b750f229811e2 \
@@ -310,17 +309,14 @@ cryptography==44.0.2 \
     --hash=sha256:efcfe97d1b3c79e486554efddeb8f6f53a4cdd4cf6086642784fa31fc384e1d7 \
     --hash=sha256:f514ef4cd14bb6fb484b4a60203e912cfcb64f2ab139e88c2274511514bf7308
     # via
-    #   -r /home/runner/work/exodus-lambda/exodus-lambda/requirements.in
     #   -r requirements.in
     #   authlib
-dill==0.3.9 \
-    --hash=sha256:468dff3b89520b474c0397703366b7b95eebe6303f108adf9b19da1f702be87a
+dill==0.4.0 \
+    --hash=sha256:44f54bf6412c2c8464c14e8243eb163690a9800dbe2c367330883b19c7561049
     # via pylint
 docutils==0.21.2 \
     --hash=sha256:dafca5b9e384f0e419294eb4d2ff9fa826435bf15f15b7bd45723e8ad76811b2
-    # via
-    #   -r /home/runner/work/exodus-lambda/exodus-lambda/requirements.in
-    #   -r requirements.in
+    # via -r requirements.in
 dparse==0.6.4 \
     --hash=sha256:fbab4d50d54d0e739fbb4dedfc3d92771003a5b9aa8545ca7a7045e3b174af57
     # via
@@ -378,9 +374,21 @@ frozenlist2==1.0.0 \
 gunicorn==23.0.0 \
     --hash=sha256:ec400d38950de4dfd418cff8328b2c8faed0edb0d517d3394e457c317908ca4d
     # via -r requirements-fakefront.in
+h11==0.16.0 \
+    --hash=sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86
+    # via httpcore
+httpcore==1.0.9 \
+    --hash=sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55
+    # via httpx
+httpx==0.28.1 \
+    --hash=sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad
+    # via safety
 idna==3.10 \
     --hash=sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3
-    # via requests
+    # via
+    #   anyio
+    #   httpx
+    #   requests
 importlib-metadata==8.6.1 \
     --hash=sha256:02a89390c1e15fdfdc0d7c6b25cb3e62650d0494005c97d6f148bf5b9787525e
     # via -r test-requirements.in
@@ -468,7 +476,9 @@ markupsafe==3.0.2 \
     # via jinja2
 marshmallow==3.26.1 \
     --hash=sha256:3350409f20a70a7e4e11a27661187b77cdcaeb20abca41c1454fe33636bea09c
-    # via safety
+    # via
+    #   -r test-requirements.in
+    #   safety
 mccabe==0.7.0 \
     --hash=sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e
     # via pylint
@@ -478,8 +488,8 @@ mdurl==0.1.2 \
 mock==5.2.0 \
     --hash=sha256:7ba87f72ca0e915175596069dbbcc7c75af7b5e9b9bc107ad6349ede0819982f
     # via -r test-requirements.in
-more-itertools==10.6.0 \
-    --hash=sha256:6eb054cb4b6db1473f6e15fcc676a08e4732548acd47c708f0e179c2c7c01e89
+more-itertools==10.7.0 \
+    --hash=sha256:d43980384673cb07d2f7d2d918c616b30c659c089ee23953f601d6609c67510e
     # via -r test-requirements.in
 mypy==1.15.0 \
     --hash=sha256:1124a18bc11a6a62887e3e137f37f53fbae476dc36c185d549d4f837a2a6a14e \
@@ -514,14 +524,14 @@ mypy==1.15.0 \
     --hash=sha256:e601a7fa172c2131bff456bb3ee08a88360760d0d2f8cbd7a75a65497e2df078 \
     --hash=sha256:f95579473af29ab73a10bada2f9722856792a36ec5af5399b653aa28360290a5
     # via -r test-requirements.in
-mypy-extensions==1.0.0 \
-    --hash=sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d
+mypy-extensions==1.1.0 \
+    --hash=sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505
     # via mypy
 nltk==3.9.1 \
     --hash=sha256:4fa26829c5b00715afe3061398a8989dc643b92ce7dd93fb4585a70930d168a1
     # via safety
-packaging==24.2 \
-    --hash=sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759
+packaging==25.0 \
+    --hash=sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484
     # via
     #   dparse
     #   gunicorn
@@ -727,7 +737,6 @@ pyyaml==6.0.2 \
     --hash=sha256:f753120cb8181e736c57ef7636e83f31b9c0d1722c516f7e86cf15b7aa57ff12 \
     --hash=sha256:ff3824dc5261f50c9b0dfb3be22b4567a6f938ccce4587b38952d85fd9e9afe4
     # via
-    #   -r /home/runner/work/exodus-lambda/exodus-lambda/requirements.in
     #   -r requirements.in
     #   bandit
     #   cdn-definitions
@@ -829,7 +838,6 @@ regex==2024.11.6 \
 requests==2.32.3 \
     --hash=sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6
     # via
-    #   -r /home/runner/work/exodus-lambda/exodus-lambda/requirements.in
     #   -r requirements.in
     #   cdn-definitions
     #   safety
@@ -890,14 +898,14 @@ ruamel-yaml-clib==0.2.12 \
     --hash=sha256:fc4b630cd3fa2cf7fce38afa91d7cfe844a9f75d7f0f36393fa98815e911d987 \
     --hash=sha256:fd5415dded15c3822597455bc02bcd66e81ef8b7a48cb71a33628fc9fdde39df
     # via ruamel-yaml
-s3transfer==0.11.4 \
-    --hash=sha256:ac265fa68318763a03bf2dc4f39d5cbd6a9e178d81cc9483ad27da33637e320d
+s3transfer==0.12.0 \
+    --hash=sha256:35b314d7d82865756edab59f7baebc6b477189e6ab4c53050e28c1de4d9cce18
     # via boto3
-safety==3.3.1 \
-    --hash=sha256:243355a961403b873c1504e3e6f79ce36b86881d559722595632d788aa92b7ea
+safety==3.4.0 \
+    --hash=sha256:176707f682e709c96bbf5462593de614cd844b7fc867d1ffacd8706d428e492f
     # via -r test-requirements.in
-safety-schemas==0.0.11 \
-    --hash=sha256:2af940c1c992d6891a6b84403a7c12fd445e20651752b1818b86c205690b3e03
+safety-schemas==0.0.14 \
+    --hash=sha256:0bf6fc4aa5e474651b714cc9e427c862792946bf052b61d5c7bec4eac4c0f254
     # via safety
 shellingham==1.5.4 \
     --hash=sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686
@@ -905,12 +913,20 @@ shellingham==1.5.4 \
 six==1.17.0 \
     --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274
     # via python-dateutil
+sniffio==1.3.1 \
+    --hash=sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2
+    # via anyio
 stevedore==5.4.1 \
     --hash=sha256:d10a31c7b86cba16c1f6e8d15416955fc797052351a56af15e608ad20811fcfe
     # via bandit
+tenacity==9.1.2 \
+    --hash=sha256:f77bf36710d8b73a50b2dd155c97b870017ad21afe6ab300326b0371b3b05138
+    # via safety
 tomlkit==0.13.2 \
     --hash=sha256:7a974427f6e119197f670fbbbeae7bef749a6c14e793db934baefc1b5f03efde
-    # via pylint
+    # via
+    #   pylint
+    #   safety
 tqdm==4.67.1 \
     --hash=sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2
     # via nltk
@@ -920,6 +936,7 @@ typer==0.15.2 \
 typing-extensions==4.13.2 \
     --hash=sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c
     # via
+    #   anyio
     #   mypy
     #   pydantic
     #   pydantic-core


### PR DESCRIPTION
marshmallow, dependency of saftey (CI), introduces breaking changes in version 4. This commit locks the version to <4 and updates requirements using `tox -e pip-compile`.